### PR TITLE
Tickets/osw 895

### DIFF
--- a/config/parameters_power.yaml
+++ b/config/parameters_power.yaml
@@ -35,6 +35,9 @@ excessive_current_motor: 20.0
 current_gain_motor: 5.0
 current_offset_motor: 0.0
 
+# Boost current fault is enabled or not.
+is_boost_current_fault_enabled: false
+
 # Time to wait for the telemetry to stabilize in millisecond. It is only
 # meaningful to track the voltage and current change once the telemetry is
 # stable.

--- a/doc/class_diagram.md
+++ b/doc/class_diagram.md
@@ -96,6 +96,7 @@ classDiagram
 
 namespace main {
   class EventQueue
+  class ErrorHandler
 }
 
 namespace mock {
@@ -130,6 +131,7 @@ PowerSystem o-- MockPlant
 PowerSystem *-- EventQueue
 PowerSystem ..> Event
 PowerSystem --> TelemetryPower
+PowerSystem ..> ErrorHandler
 ```
 
 ## Control

--- a/doc/version_history.md
+++ b/doc/version_history.md
@@ -1,5 +1,16 @@
 # Version Histroy
 
+0.2.6
+
+- Fix the digital input of interlock bit in **MockPlant**.
+- Add the **is_boost_current_fault_enabled** to `parameters_power.yaml`.
+- Check the power health and interlock in the power system and error handler.
+If there is issue, fail the power command.
+- Improve the `TcpServer.write_jsons()` and `TcpServer.flush()` to consider the system resource of **std::io::ErrorKind::WouldBlock**.
+- Fix the `CommandSetExternalElevation.execute()` to use the lower case.
+- Log the current closed-loop control mode.
+- Improve the control loop process to make sure to process the non-telemetry command when there is the telemetry in each loop.
+
 0.2.5
 
 - Track the power command status.

--- a/src/command/command_control_loop.rs
+++ b/src/command/command_control_loop.rs
@@ -325,8 +325,8 @@ impl Command for CommandSetExternalElevation {
         control_loop: Option<&mut ControlLoop>,
         _controller: Option<&mut Controller>,
     ) -> Option<()> {
-        if message["compName"].as_str()? != "mtmount" {
-            error!("The compName is not mtmount.");
+        if message["compName"].as_str()?.to_lowercase() != "mtmount" {
+            error!("The lowercase of compName is not mtmount.");
 
             return None;
         }
@@ -602,6 +602,20 @@ mod tests {
         assert_eq!(
             control_loop.telemetry.inclinometer.get("external"),
             Some(&1.0)
+        );
+
+        assert!(command
+            .execute(
+                &json!({"compName": "MTMount", "actualPosition": 2.0}),
+                None,
+                Some(&mut control_loop),
+                None
+            )
+            .is_some());
+
+        assert_eq!(
+            control_loop.telemetry.inclinometer.get("external"),
+            Some(&2.0)
         );
     }
 

--- a/src/control/control_loop.rs
+++ b/src/control/control_loop.rs
@@ -19,6 +19,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use log::info;
 use nalgebra::SMatrix;
 use std::path::Path;
 
@@ -129,6 +130,7 @@ impl ControlLoop {
     /// * `mode` - The control mode to be set.
     pub fn update_control_mode(&mut self, mode: ClosedLoopControlMode) {
         self._mode = mode;
+        info!("Control mode is set to: {:?}.", mode);
 
         self.event_queue
             .add_event(Event::get_message_closed_loop_control_mode(mode));

--- a/src/mock/mock_plant.rs
+++ b/src/mock/mock_plant.rs
@@ -247,6 +247,10 @@ impl MockPlant {
             ]);
         }
 
+        if !self.power_system_motor.is_power_on {
+            bits.push(DigitalInput::InterlockPowerRelay);
+        }
+
         if !self.power_system_motor.is_breaker_enabled() {
             bits.extend_from_slice(&[
                 DigitalInput::J1W9N1MotorPowerBreaker,
@@ -258,7 +262,6 @@ impl MockPlant {
                 DigitalInput::J3W11N1MotorPowerBreaker,
                 DigitalInput::J3W11N2MotorPowerBreaker,
                 DigitalInput::J3W11N3MotorPowerBreaker,
-                DigitalInput::InterlockPowerRelay,
             ]);
         }
 
@@ -715,7 +718,19 @@ mod tests {
             TEST_DIGITAL_INPUT_POWER_COMM
         );
 
+        // Check the interlock bit
+        assert!(
+            (mock_plant.get_digital_input() & DigitalInput::InterlockPowerRelay.bit_value()) != 0
+        );
+
+        mock_plant.power_system_motor.is_power_on = true;
+
+        assert!(
+            (mock_plant.get_digital_input() & DigitalInput::InterlockPowerRelay.bit_value()) == 0
+        );
+
         // Motor power
+        mock_plant.power_system_motor.is_power_on = false;
         run_until_breaker_enabled(&mut mock_plant.power_system_motor);
 
         assert_eq!(

--- a/src/power/config_power.rs
+++ b/src/power/config_power.rs
@@ -49,6 +49,8 @@ pub struct ConfigPower {
     // Gain and offset for the motor current.
     pub current_gain_motor: f64,
     pub current_offset_motor: f64,
+    // Boost current fault is enabled or not.
+    pub is_boost_current_fault_enabled: bool,
     // Time to wait for the telemetry to stabilize in millisecond.
     pub telemetry_stable_time: i32,
     // Breaker operating voltage rise time in millisecond for the communication
@@ -127,6 +129,11 @@ impl ConfigPower {
 
             current_gain_motor: get_parameter(filepath, "current_gain_motor"),
             current_offset_motor: get_parameter(filepath, "current_offset_motor"),
+
+            is_boost_current_fault_enabled: get_parameter(
+                filepath,
+                "is_boost_current_fault_enabled",
+            ),
 
             telemetry_stable_time: get_parameter(filepath, "telemetry_stable_time"),
 

--- a/src/power/power_system_process.rs
+++ b/src/power/power_system_process.rs
@@ -159,18 +159,24 @@ impl PowerSystemProcess {
                 // Read the module and get the telemetry.
                 let telemetry = self._power_system.get_telemetry_data();
 
+                // Check the power supply error.
+                let digital_output = telemetry.digital_output;
+                let digital_input = telemetry.digital_input;
+                self._power_system
+                    .check_power_supply_error(digital_output, digital_input);
+
                 // Transition the states based on the telemetry data.
                 self._power_system.transition_state(
                     PowerType::Communication,
                     telemetry.power_raw["commVoltage"],
-                    telemetry.digital_output,
-                    telemetry.digital_input,
+                    digital_output,
+                    digital_input,
                 );
                 self._power_system.transition_state(
                     PowerType::Motor,
                     telemetry.power_raw["motorVoltage"],
-                    telemetry.digital_output,
-                    telemetry.digital_input,
+                    digital_output,
+                    digital_input,
                 );
 
                 // Send the telemetry and event data to the model and ignore the


### PR DESCRIPTION
- Fix the digital input of interlock bit in **MockPlant**.
- Add the **is_boost_current_fault_enabled** to `parameters_power.yaml`.
- Check the power health and interlock in the power system and error handler.
If there is issue, fail the power command.
- Improve the `TcpServer.write_jsons()` and `TcpServer.flush()` to consider the system resource of **std::io::ErrorKind::WouldBlock**.
- Fix the `CommandSetExternalElevation.execute()` to use the lower case.
- Log the current closed-loop control mode.
- Improve the control loop process to make sure to process the non-telemetry command when there is the telemetry in each loop.