### PR TITLE
Tickets/osw 1570

### DIFF
--- a/config/parameters_app.yaml
+++ b/config/parameters_app.yaml
@@ -13,7 +13,7 @@ port_command_csc: 50000
 port_telemetry_csc: 50001
 
 # Timeout in milliseconds
-timeout: 100
+timeout: 50
 
 # Is the application running in the mirror mode? If not, it is running with the
 # surrogate. The main difference is the control parameters.

--- a/doc/README.md
+++ b/doc/README.md
@@ -67,8 +67,6 @@ The followings are the commands:
 - CommandMoveActuators
 - CommandSetConfig
 - CommandSetExternalElevation
-- CommandGetInnerLoopControlMode
-- CommandSetInnerLoopControlMode
 
 See [here](../src/command/command_control_loop.rs) for the details.
 

--- a/doc/class_diagram.md
+++ b/doc/class_diagram.md
@@ -215,6 +215,7 @@ Telemetry o-- TelemetryControlLoop
 namespace command {
   class CommandSchema
   class CommandControlLoop
+  class CommandDataAcquisition
 }
 
 CommandSchema "1" *-- "n" CommandControlLoop
@@ -223,6 +224,7 @@ ControlLoopProcess ..> Config
 ControlLoopProcess *-- ControlLoop
 ControlLoopProcess *-- CommandSchema
 ControlLoopProcess ..> CommandControlLoop
+ControlLoopProcess ..> CommandDataAcquisition
 ControlLoopProcess ..> Telemetry
 
 CommandControlLoop --> ControlLoop
@@ -232,7 +234,7 @@ ControlLoop *-- ClosedLoop
 ControlLoop *-- OpenLoop
 ControlLoop *-- TelemetryControlLoop
 ControlLoop *-- EventQueue
-ControlLoop o-- MockPlant
+ControlLoop ..> MockPlant
 ControlLoop ..> Event
 
 Config *-- Lut

--- a/doc/version_history.md
+++ b/doc/version_history.md
@@ -1,5 +1,21 @@
 # Version History
 
+0.4.0
+
+- Put the **timeout** value to be 50 ms in `parameters_app.yaml`.
+- Improve the clippy format.
+- Put the `MockPlant.calculate_ims_readings()` to be static.
+- Add the `disp_matrix_inv` field in **Config**.
+- Remove the `_is_simulation_mode` field in **OpenLoop**.
+- Remove the simulation of **MockPlant** from the **ControlLoop**.
+The related simulation goes to the **DataAcquisition** instead.
+- Add the command of data acquisition to the **Model**.
+- Use the `Receiver.recv_timeout()` instead of `Receiver.try_recv()` in **CommandServer**,  **TelemetryServer**, and **DataAcquisitionProcess** (in the test).
+- Use the `Receiver.recv_timeout()` in the tests of **PowerSystemProcess**.
+- Add the `seq_id_move_actuator_steps` field in **CommandMoveActuatorSteps** and **TelemetryControlLoop**.
+The **DataAcquisition** will cache this value.
+- Fix the switch of commander in `model.rs`.
+
 0.3.2
 
 - Update the dependencies.

--- a/src/command/command_control_loop.rs
+++ b/src/command/command_control_loop.rs
@@ -28,9 +28,7 @@ use crate::constants::{NUM_ACTUATOR, NUM_AXIAL_ACTUATOR, NUM_TANGENT_LINK};
 use crate::control::control_loop::ControlLoop;
 use crate::controller::Controller;
 use crate::daq::data_acquisition::DataAcquisition;
-use crate::enums::{
-    ActuatorDisplacementUnit, ClosedLoopControlMode, CommandActuator, InnerLoopControlMode,
-};
+use crate::enums::{ActuatorDisplacementUnit, ClosedLoopControlMode, CommandActuator};
 use crate::power::power_system::PowerSystem;
 
 /// Command to set the closed-loop control mode.
@@ -341,73 +339,7 @@ impl Command for CommandSetExternalElevation {
         }
 
         let control = control_loop?;
-        control.telemetry.inclinometer.insert(
-            String::from("external"),
-            message["actualPosition"].as_f64()?,
-        );
-
-        Some(())
-    }
-}
-
-/// Command to set the mode of inner-loop controller.
-pub struct CommandSetInnerLoopControlMode;
-impl Command for CommandSetInnerLoopControlMode {
-    fn name(&self) -> &str {
-        "cmd_setInnerLoopControlMode"
-    }
-
-    fn execute(
-        &self,
-        message: &Value,
-        _data_acquisition: Option<&mut DataAcquisition>,
-        _power_system: Option<&mut PowerSystem>,
-        control_loop: Option<&mut ControlLoop>,
-        _controller: Option<&mut Controller>,
-    ) -> Option<()> {
-        let control = control_loop?;
-
-        let addresses = message["addresses"].as_array()?;
-        for address in addresses {
-            let address = address.as_u64()? as usize;
-            let mode = InnerLoopControlMode::from_repr(message["mode"].as_u64()? as u8)?;
-            if let Err(err) = control.set_ilc_mode(address, mode) {
-                error!("Failed to set the inner-loop control mode: {err}");
-
-                return None;
-            }
-        }
-
-        Some(())
-    }
-}
-
-/// Command to get the mode of inner-loop controller.
-pub struct CommandGetInnerLoopControlMode;
-impl Command for CommandGetInnerLoopControlMode {
-    fn name(&self) -> &str {
-        "cmd_getInnerLoopControlMode"
-    }
-
-    fn execute(
-        &self,
-        message: &Value,
-        _data_acquisition: Option<&mut DataAcquisition>,
-        _power_system: Option<&mut PowerSystem>,
-        control_loop: Option<&mut ControlLoop>,
-        _controller: Option<&mut Controller>,
-    ) -> Option<()> {
-        let control = control_loop?;
-
-        let addresses = message["addresses"].as_array()?;
-        for address in addresses {
-            let address = address.as_u64()? as usize;
-            if let Err(err) = control.get_ilc_mode(address) {
-                error!("Failed to get the inner-loop control mode: {err}");
-
-                return None;
-            }
-        }
+        control.external_elevation_angle = message["actualPosition"].as_f64()?;
 
         Some(())
     }
@@ -618,10 +550,7 @@ mod tests {
             )
             .is_some());
 
-        assert_eq!(
-            control_loop.telemetry.inclinometer.get("external"),
-            Some(&1.0)
-        );
+        assert_eq!(control_loop.external_elevation_angle, 1.0);
 
         assert!(command
             .execute(
@@ -633,59 +562,6 @@ mod tests {
             )
             .is_some());
 
-        assert_eq!(
-            control_loop.telemetry.inclinometer.get("external"),
-            Some(&2.0)
-        );
-    }
-
-    #[test]
-    fn test_command_set_inner_loop_control_mode() {
-        let mut control_loop = create_control_loop();
-
-        let command = CommandSetInnerLoopControlMode;
-
-        assert_eq!(command.name(), "cmd_setInnerLoopControlMode");
-
-        assert!(command
-            .execute(
-                &json!({"addresses": [0, 1], "mode": 2}),
-                None,
-                None,
-                Some(&mut control_loop),
-                None
-            )
-            .is_some());
-
-        assert_eq!(
-            control_loop.get_ilc_mode(0).unwrap(),
-            InnerLoopControlMode::Disabled
-        );
-        assert_eq!(
-            control_loop.get_ilc_mode(1).unwrap(),
-            InnerLoopControlMode::Disabled
-        );
-    }
-
-    #[test]
-    fn test_command_get_inner_loop_control_mode() {
-        let mut control_loop = create_control_loop();
-
-        let command = CommandGetInnerLoopControlMode;
-
-        assert_eq!(command.name(), "cmd_getInnerLoopControlMode");
-
-        let _ = control_loop.set_ilc_mode(0, InnerLoopControlMode::Enabled);
-        let _ = control_loop.set_ilc_mode(1, InnerLoopControlMode::Enabled);
-
-        assert!(command
-            .execute(
-                &json!({"addresses": [0, 1]}),
-                None,
-                None,
-                Some(&mut control_loop),
-                None
-            )
-            .is_some());
+        assert_eq!(control_loop.external_elevation_angle, 2.0);
     }
 }

--- a/src/command/command_data_acquisition.rs
+++ b/src/command/command_data_acquisition.rs
@@ -127,6 +127,7 @@ impl Command for CommandMoveActuatorSteps {
         _controller: Option<&mut Controller>,
     ) -> Option<()> {
         let mut steps = Vec::new();
+        let seq_id = message["seq_id_move_actuator_steps"].as_i64()?;
         let step_list = message["steps"].as_array()?;
         for step_item in step_list {
             let step = step_item.as_i64()?;
@@ -134,7 +135,7 @@ impl Command for CommandMoveActuatorSteps {
         }
 
         let system = data_acquisition?;
-        system.move_actuator_steps(&steps)?;
+        system.move_actuator_steps(seq_id as i32, &steps)?;
 
         Some(())
     }
@@ -272,7 +273,7 @@ mod tests {
         data_acquisition.set_mode(DataAcquisitionMode::Telemetry);
         assert!(command
             .execute(
-                &json!({"steps": steps}),
+                &json!({"seq_id_move_actuator_steps": 1, "steps": steps}),
                 Some(&mut data_acquisition),
                 None,
                 None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,8 @@ pub struct Config {
     // Matrix and offset for the IMS displacement.
     pub disp_matrix: SMatrix<f64, NUM_SPACE_DEGREE_OF_FREEDOM, NUM_IMS_READING>,
     pub disp_offset: SVector<f64, NUM_IMS_READING>,
+    // Pseudo-inverse of the displacement matrix for the IMS.
+    pub disp_matrix_inv: SMatrix<f64, NUM_IMS_READING, NUM_SPACE_DEGREE_OF_FREEDOM>,
     // Force limits
     pub force_limit: HashMap<String, f64>,
     // The threshold of the tangent force error in Newton.
@@ -210,6 +212,10 @@ impl Config {
 
             disp_matrix,
             disp_offset,
+
+            disp_matrix_inv: disp_matrix
+                .pseudo_inverse(f64::EPSILON)
+                .expect("Should be able to compute the pseudo inverse of displacement matrix."),
 
             force_limit,
 

--- a/src/control/control_loop.rs
+++ b/src/control/control_loop.rs
@@ -34,9 +34,7 @@ use crate::control::math_tool::{
     rigid_body_to_actuator_displacement,
 };
 use crate::control::open_loop::OpenLoop;
-use crate::enums::{
-    ActuatorDisplacementUnit, ClosedLoopControlMode, CommandActuator, InnerLoopControlMode,
-};
+use crate::enums::{ActuatorDisplacementUnit, ClosedLoopControlMode, CommandActuator};
 use crate::event_queue::EventQueue;
 use crate::mock::mock_plant::MockPlant;
 use crate::telemetry::{event::Event, telemetry_control_loop::TelemetryControlLoop};
@@ -54,16 +52,22 @@ pub struct ControlLoop {
     _mode: ClosedLoopControlMode,
     // Configuration.
     pub config: Config,
-    // Telemetry.
-    pub telemetry: TelemetryControlLoop,
     // Mirror is in position or not.
     pub is_in_position: bool,
+    // External elevation angle in degree.
+    pub external_elevation_angle: f64,
+    // Applied force in Newton.
+    pub applied_force: Vec<f64>,
+    // Current hardpoint displacements in meter.
+    _current_hardpoint_displacement: Vec<f64>,
     // Steps to position the mirror.
     pub steps_position_mirror: Vec<i32>,
     // Events to publish
     pub event_queue: EventQueue,
-    // Plant model
-    pub plant: Option<MockPlant>,
+    // Steps to move the actuators
+    _steps_to_move_actuators: Option<Vec<i32>>,
+    // Is the simulation mode enabled or not.
+    _is_simulation_mode: bool,
 }
 
 impl ControlLoop {
@@ -78,24 +82,6 @@ impl ControlLoop {
     /// # Returns
     /// A new control loop.
     pub fn new(config: &Config, is_mirror: bool, is_simulation_mode: bool) -> Self {
-        // Plant model
-        let telemetry = TelemetryControlLoop::new();
-        let plant = if is_simulation_mode {
-            // Use the M2 stiffness matrix here intentionally to match the
-            // simulation mode of ts_mtm2_cell.
-            let mut mock_plant = MockPlant::new(
-                &read_file_stiffness(Path::new("config/stiff_matrix_m2.yaml")),
-                // Zenith angle by default
-                90.0,
-            );
-            mock_plant.power_system_communication.is_power_on = true;
-            mock_plant.power_system_motor.is_power_on = true;
-
-            Option::Some(mock_plant)
-        } else {
-            Option::None
-        };
-
         Self {
             is_mirror,
 
@@ -106,21 +92,25 @@ impl ControlLoop {
                 &config.hardpoints,
                 &config.cell_geometry.loc_act_axial,
             ),
-            _open_loop: OpenLoop::new(is_simulation_mode),
+            _open_loop: OpenLoop::new(),
 
             _mode: ClosedLoopControlMode::Idle,
 
             config: config.clone(),
 
-            telemetry,
-
             is_in_position: false,
+            external_elevation_angle: 0.0,
+            applied_force: vec![0.0; NUM_ACTUATOR],
+
+            _current_hardpoint_displacement: vec![0.0; NUM_HARDPOINTS],
 
             steps_position_mirror: vec![0; NUM_ACTUATOR],
 
             event_queue: EventQueue::new(),
 
-            plant,
+            _steps_to_move_actuators: None,
+
+            _is_simulation_mode: is_simulation_mode,
         }
     }
 
@@ -316,49 +306,43 @@ impl ControlLoop {
         self._closed_loop.hd_comp = hd_comp;
     }
 
-    /// Is the simulation mode or not.
-    ///
-    /// # Returns
-    /// True if the simulation mode is enabled. Otherwise, false.
-    pub fn is_simulation_mode(&self) -> bool {
-        self.plant.is_some()
-    }
-
     /// Step the control loop.
+    ///
+    /// # Arguments
+    /// * `telemetry` - The processed telemetry data. This function will update
+    ///   the telemetry data as well.
     ///
     /// # Panics
     /// If not in simulation mode.
-    pub fn step(&mut self) {
+    pub fn step(&mut self, telemetry: &mut TelemetryControlLoop) {
         // In idle mode, do nothing.
         if self._mode == ClosedLoopControlMode::Idle {
             return;
         }
 
-        self.update_telemetry_data();
-        self.process_telemetry_data();
-
-        self.update_lut_forces();
+        self.update_lut_forces(telemetry);
 
         // Calculate the hardpoint correction and the is_in_position flag.
-        let demanded_force = self.get_demanded_force(&self.telemetry.forces["applied"]);
+        let demanded_force = self.get_demanded_force(telemetry);
         let config = &self.config;
         let (steps_closed_loop_control, hardpoint_correction, is_in_position) =
             self._closed_loop.calc_actuator_steps(
                 &demanded_force,
-                &self.telemetry.forces["measured"],
+                &telemetry.forces["measured"],
                 &config.hardpoints,
                 self.is_in_position,
             );
 
         self.is_in_position = is_in_position;
 
-        // Update the telemetry data.
-        self.telemetry
-            .forces
-            .insert(String::from("hardpointCorrection"), hardpoint_correction);
+        // Update the telemetry data for the hardpoint correction.
+        self.update_hardpoint_correction_to_telemetry(telemetry, &hardpoint_correction);
 
-        // In telemetry only mode, do nothing after getting the telemetry.
-        if self._mode == ClosedLoopControlMode::TelemetryOnly {
+        // In telemetry only mode or there is still the steps to move, do
+        // nothing after updating the telemetry.
+        if (self._mode == ClosedLoopControlMode::TelemetryOnly)
+            || self._steps_to_move_actuators.is_some()
+        {
             return;
         }
 
@@ -404,154 +388,88 @@ impl ControlLoop {
                 });
         }
 
-        // Do the actuator movement.
-        if self.is_simulation_mode() {
-            if let Some(plant) = &mut self.plant {
-                plant.move_actuator_steps(&steps);
-            }
-        } else {
-            // Update the hardware.
-            panic!("Not implemented yet.");
-        }
+        // Cache the steps of actuator movement
+        self._steps_to_move_actuators = Some(steps);
     }
 
-    /// Update the telemetry data related to the plant/hardware.
+    /// Take the steps to move the actuators.
     ///
-    /// # Panics
-    /// If not in simulation mode.
-    fn update_telemetry_data(&mut self) {
-        self.telemetry.is_in_position = self.is_in_position;
-        // Get the telemetry from the plant.
-        if self.is_simulation_mode() {
-            // Get the telemetry from the plant.
-            if let Some(plant) = &mut self.plant {
-                if plant.power_system_communication.is_power_on {
-                    // Inclinometer
-                    self.telemetry
-                        .inclinometer
-                        .insert(String::from("raw"), plant.inclinometer_angle);
-
-                    // Get the actuator ILC data
-                    let (ilc_status, ilc_encoders, forces) = plant.get_actuator_ilc_data();
-
-                    // Get the actuator step and position based on the encoder
-                    ilc_encoders.iter().enumerate().for_each(|(idx, encoder)| {
-                        let (step, position) =
-                            self._open_loop.actuators[idx].encoder_to_step_and_position(*encoder);
-                        self.telemetry.actuator_steps[idx] = step;
-                        self.telemetry.actuator_positions[idx] = position;
-                    });
-
-                    // Forces
-                    self.telemetry
-                        .forces
-                        .insert(String::from("measured"), forces);
-
-                    // ILC
-                    self.telemetry.ilc_status = ilc_status;
-                    self.telemetry.ilc_encoders = ilc_encoders;
-
-                    // Temperatures
-                    self.telemetry
-                        .temperature
-                        .insert(String::from("ring"), plant.temperature_ring.clone());
-                    self.telemetry
-                        .temperature
-                        .insert(String::from("intake"), plant.temperature_intake.clone());
-                    self.telemetry
-                        .temperature
-                        .insert(String::from("exhaust"), plant.temperature_exhaust.clone());
-
-                    // Simulate IMS readings
-                    let (theta_z, delta_z) = plant.calculate_ims_readings(
-                        self.telemetry.mirror_position["x"],
-                        self.telemetry.mirror_position["y"],
-                        self.telemetry.mirror_position["z"],
-                        self.telemetry.mirror_position["xRot"],
-                        self.telemetry.mirror_position["yRot"],
-                        self.telemetry.mirror_position["zRot"],
-                    );
-
-                    self.telemetry
-                        .displacement_sensors
-                        .insert(String::from("thetaZ"), theta_z);
-                    self.telemetry
-                        .displacement_sensors
-                        .insert(String::from("deltaZ"), delta_z);
-                }
-            }
-        } else {
-            // Get the telemetry from the hardware.
-            panic!("Not implemented yet.");
-        }
+    /// # Returns
+    /// Option of the vector of steps to move the actuators.
+    pub fn take_steps_to_move_actuators(&mut self) -> Option<Vec<i32>> {
+        self._steps_to_move_actuators.take()
     }
 
     /// Process the telemetry data.
-    fn process_telemetry_data(&mut self) {
-        let config = &self.config;
+    ///
+    /// # Arguments
+    /// * `telemetry` - The telemetry data to be processed.
+    pub fn process_telemetry_data(&mut self, telemetry: &mut TelemetryControlLoop) {
+        // Set the is_in_position flag.
+        telemetry.is_in_position = self.is_in_position;
+
+        // Set the external elevation angle.
+        telemetry
+            .inclinometer
+            .insert(String::from("external"), self.external_elevation_angle);
+
+        // Set the applied force.
+        telemetry
+            .forces
+            .insert(String::from("applied"), self.applied_force.clone());
+
+        // Get the actuator step and position based on the encoder
+        telemetry
+            .ilc_encoders
+            .iter()
+            .enumerate()
+            .for_each(|(idx, encoder)| {
+                let (step, position) =
+                    self._open_loop.actuators[idx].encoder_to_step_and_position(*encoder);
+                telemetry.actuator_steps[idx] = step;
+                telemetry.actuator_positions[idx] = position;
+            });
 
         // Process the inclinometer angle
-        self.telemetry.inclinometer.insert(
+        telemetry.inclinometer.insert(
             String::from("processed"),
             correct_inclinometer_angle(
-                self.telemetry.inclinometer["raw"],
-                config.inclinometer_offset,
+                telemetry.inclinometer["raw"],
+                self.config.inclinometer_offset,
             ),
         );
-        self.telemetry.inclinometer.insert(
+        telemetry.inclinometer.insert(
             String::from("zenith"),
-            90.0 - self.telemetry.inclinometer["processed"],
+            90.0 - telemetry.inclinometer["processed"],
         );
 
         // Calculate the net total forces.
-        let (fx, fy, fz) = self.calculate_xyz_net_forces(&self.telemetry.forces["measured"]);
-        self.telemetry
-            .net_total_forces
-            .insert(String::from("fx"), fx);
-        self.telemetry
-            .net_total_forces
-            .insert(String::from("fy"), fy);
-        self.telemetry
-            .net_total_forces
-            .insert(String::from("fz"), fz);
+        let (fx, fy, fz) = self.calculate_xyz_net_forces(&telemetry.forces["measured"]);
+        telemetry.net_total_forces.insert(String::from("fx"), fx);
+        telemetry.net_total_forces.insert(String::from("fy"), fy);
+        telemetry.net_total_forces.insert(String::from("fz"), fz);
 
         // Calculate the net total moments.
-        let (mx, my, mz) = self.calculate_xyz_net_moments(&self.telemetry.forces["measured"]);
-        self.telemetry
-            .net_total_moments
-            .insert(String::from("mx"), mx);
-        self.telemetry
-            .net_total_moments
-            .insert(String::from("my"), my);
-        self.telemetry
-            .net_total_moments
-            .insert(String::from("mz"), mz);
-
-        // Calculate the force balance.
-        let (fx, fy, fz) =
-            self.calculate_xyz_net_forces(&self.telemetry.forces["hardpointCorrection"]);
-        let (mx, my, mz) =
-            self.calculate_xyz_net_moments(&self.telemetry.forces["hardpointCorrection"]);
-        self.telemetry.force_balance.insert(String::from("fx"), fx);
-        self.telemetry.force_balance.insert(String::from("fy"), fy);
-        self.telemetry.force_balance.insert(String::from("fz"), fz);
-        self.telemetry.force_balance.insert(String::from("mx"), mx);
-        self.telemetry.force_balance.insert(String::from("my"), my);
-        self.telemetry.force_balance.insert(String::from("mz"), mz);
+        let (mx, my, mz) = self.calculate_xyz_net_moments(&telemetry.forces["measured"]);
+        telemetry.net_total_moments.insert(String::from("mx"), mx);
+        telemetry.net_total_moments.insert(String::from("my"), my);
+        telemetry.net_total_moments.insert(String::from("mz"), mz);
 
         // Calculate the tangent force error.
-        self.telemetry.tangent_force_error = self.calculate_tangent_force_error(
-            &(self.telemetry.forces["measured"][NUM_AXIAL_ACTUATOR..]),
+        telemetry.tangent_force_error = self.calculate_tangent_force_error(
+            &(telemetry.forces["measured"][NUM_AXIAL_ACTUATOR..]),
+            telemetry.inclinometer["zenith"],
         );
 
         // Calculate the rigid body position (hardpoints).
+        self.set_current_hardpoint_displacement(&telemetry.actuator_positions);
         if let Ok((x, y, z, rx, ry, rz)) = hardpoint_to_rigid_body(
-            &config.cell_geometry.loc_act_axial,
-            &config.cell_geometry.loc_act_tangent,
-            config.cell_geometry.radius_act_tangent,
-            &config.hardpoints,
-            &self.get_current_hardpoint_displacement(),
-            &config.disp_hardpoint_home,
+            &self.config.cell_geometry.loc_act_axial,
+            &self.config.cell_geometry.loc_act_tangent,
+            self.config.cell_geometry.radius_act_tangent,
+            &self.config.hardpoints,
+            &self._current_hardpoint_displacement,
+            &self.config.disp_hardpoint_home,
         ) {
             // Need to update the unit from "m to um" and "rad to arcsec".
             let m_to_um = 1e6;
@@ -559,52 +477,94 @@ impl ControlLoop {
             // 1 rad × (180/pi) x 3600 arcsec ~ 206265
             let radian_to_arcsec = 206265.0;
 
-            self.telemetry
+            telemetry
                 .mirror_position
                 .insert(String::from("x"), x * m_to_um);
-            self.telemetry
+            telemetry
                 .mirror_position
                 .insert(String::from("y"), y * m_to_um);
-            self.telemetry
+            telemetry
                 .mirror_position
                 .insert(String::from("z"), z * m_to_um);
-            self.telemetry
+            telemetry
                 .mirror_position
                 .insert(String::from("xRot"), rx * radian_to_arcsec);
-            self.telemetry
+            telemetry
                 .mirror_position
                 .insert(String::from("yRot"), ry * radian_to_arcsec);
-            self.telemetry
+            telemetry
                 .mirror_position
                 .insert(String::from("zRot"), rz * radian_to_arcsec);
         }
 
+        // Simulate IMS readings
+        if self._is_simulation_mode {
+            let (theta_z, delta_z) = MockPlant::calculate_ims_readings(
+                &self.config.disp_matrix_inv,
+                &self.config.disp_offset,
+                telemetry.mirror_position["x"],
+                telemetry.mirror_position["y"],
+                telemetry.mirror_position["z"],
+                telemetry.mirror_position["xRot"],
+                telemetry.mirror_position["yRot"],
+                telemetry.mirror_position["zRot"],
+            );
+
+            telemetry
+                .displacement_sensors
+                .insert(String::from("thetaZ"), theta_z);
+            telemetry
+                .displacement_sensors
+                .insert(String::from("deltaZ"), delta_z);
+        }
+
         // Calculate the rigid body position (IMS).
         let (x, y, z, rx, ry, rz) = calculate_position_ims(
-            &config.disp_matrix,
-            &config.disp_offset,
-            &self.telemetry.displacement_sensors["thetaZ"],
-            &self.telemetry.displacement_sensors["deltaZ"],
+            &self.config.disp_matrix,
+            &self.config.disp_offset,
+            &telemetry.displacement_sensors["thetaZ"],
+            &telemetry.displacement_sensors["deltaZ"],
         );
 
-        self.telemetry
-            .mirror_position_ims
-            .insert(String::from("x"), x);
-        self.telemetry
-            .mirror_position_ims
-            .insert(String::from("y"), y);
-        self.telemetry
-            .mirror_position_ims
-            .insert(String::from("z"), z);
-        self.telemetry
+        telemetry.mirror_position_ims.insert(String::from("x"), x);
+        telemetry.mirror_position_ims.insert(String::from("y"), y);
+        telemetry.mirror_position_ims.insert(String::from("z"), z);
+        telemetry
             .mirror_position_ims
             .insert(String::from("xRot"), rx);
-        self.telemetry
+        telemetry
             .mirror_position_ims
             .insert(String::from("yRot"), ry);
-        self.telemetry
+        telemetry
             .mirror_position_ims
             .insert(String::from("zRot"), rz);
+    }
+
+    /// Update the hardpoint correction to the telemetry data.
+    ///
+    /// # Arguments
+    /// * `telemetry` - The telemetry data to be updated.
+    /// * `hardpoint_correction` - The hardpoint correction in Newton.
+    fn update_hardpoint_correction_to_telemetry(
+        &self,
+        telemetry: &mut TelemetryControlLoop,
+        hardpoint_correction: &[f64],
+    ) {
+        // Calculate the force balance.
+        let (fx, fy, fz) = self.calculate_xyz_net_forces(hardpoint_correction);
+        let (mx, my, mz) = self.calculate_xyz_net_moments(hardpoint_correction);
+
+        // Update the telemetry data.
+        telemetry.forces.insert(
+            String::from("hardpointCorrection"),
+            hardpoint_correction.to_vec(),
+        );
+        telemetry.force_balance.insert(String::from("fx"), fx);
+        telemetry.force_balance.insert(String::from("fy"), fy);
+        telemetry.force_balance.insert(String::from("fz"), fz);
+        telemetry.force_balance.insert(String::from("mx"), mx);
+        telemetry.force_balance.insert(String::from("my"), my);
+        telemetry.force_balance.insert(String::from("mz"), mz);
     }
 
     /// Calculate the net forces in the x, y, and z directions.
@@ -666,10 +626,11 @@ impl ControlLoop {
     ///
     /// # Arguments
     /// * `tangent_forces` - Currant tangent force (A1-A6) in Newton.
+    /// * `zenith_angle` - The zenith angle in degree.
     ///
     /// # Returns
     /// The tangent force error.
-    fn calculate_tangent_force_error(&self, tangent_forces: &[f64]) -> Vec<f64> {
+    fn calculate_tangent_force_error(&self, tangent_forces: &[f64], zenith_angle: f64) -> Vec<f64> {
         // Calculate the individual tangent force error
 
         // When the mirror is on tilt orientation, tangential forces (A2, A3,
@@ -688,7 +649,7 @@ impl ControlLoop {
         let gravitational_acceleration = 9.8;
         let mirror_weight_projection = self.config.mirror_weight_kg
             * gravitational_acceleration
-            * self.telemetry.inclinometer["zenith"].to_radians().sin();
+            * zenith_angle.to_radians().sin();
         let divided_mirror_division = mirror_weight_projection / (indexes.len() as f64);
 
         let directions = [1.0, 1.0, -1.0, -1.0];
@@ -717,42 +678,49 @@ impl ControlLoop {
         tangent_force_error
     }
 
-    /// Get the current hardpoint displacements in meter.
+    /// Set the current hardpoint displacements in meter.
+    ///
+    /// # Arguments
+    /// * `actuator_positions` - The actuator positions in millimeter.
     ///
     /// # Returns
     /// Current hardpoint displacements in meter.
-    fn get_current_hardpoint_displacement(&self) -> Vec<f64> {
+    fn set_current_hardpoint_displacement(&mut self, actuator_positions: &[f64]) {
         // Change the unit from millimeter to meter.
-        self.config
+        self._current_hardpoint_displacement = self
+            .config
             .hardpoints
             .iter()
-            .map(|&idx| self.telemetry.actuator_positions[idx] * 1e-3)
-            .collect()
+            .map(|idx| actuator_positions[*idx] * 1e-3)
+            .collect();
     }
 
     /// Update the look-up table (LUT) forces.
-    fn update_lut_forces(&mut self) {
+    ///
+    /// # Arguments
+    /// * `telemetry` - The telemetry data to be updated.
+    fn update_lut_forces(&mut self, telemetry: &mut TelemetryControlLoop) {
         let config = &self.config;
 
         // Calculate the LUT forces.
         let lut_angle = if config.use_external_elevation_angle {
-            self.telemetry.inclinometer["external"]
+            telemetry.inclinometer["external"]
         } else {
-            self.telemetry.inclinometer["processed"]
+            telemetry.inclinometer["processed"]
         };
 
         let (lut_gravity, lut_temperature) = config.lut.get_lut_forces(
             lut_angle,
-            &self.telemetry.temperature["ring"],
+            &telemetry.temperature["ring"],
             &config.ref_temperature,
             config.enable_lut_temperature,
         );
 
         // Update the telemetry data.
-        self.telemetry
+        telemetry
             .forces
             .insert(String::from("lutGravity"), lut_gravity);
-        self.telemetry
+        telemetry
             .forces
             .insert(String::from("lutTemperature"), lut_temperature);
     }
@@ -760,15 +728,15 @@ impl ControlLoop {
     /// Get the demanded force.
     ///
     /// # Arguments
-    /// * `applied_force` - The applied force in Newton.
+    /// * `telemetry` - The telemetry data.
     ///
     /// # Returns
     /// The demanded force in Newton.
-    pub fn get_demanded_force(&self, applied_force: &[f64]) -> Vec<f64> {
-        let forces = &self.telemetry.forces;
+    pub fn get_demanded_force(&self, telemetry: &TelemetryControlLoop) -> Vec<f64> {
+        let forces = &telemetry.forces;
         (0..NUM_ACTUATOR)
             .map(|idx| {
-                applied_force[idx] + forces["lutGravity"][idx] + forces["lutTemperature"][idx]
+                forces["applied"][idx] + forces["lutGravity"][idx] + forces["lutTemperature"][idx]
             })
             .collect()
     }
@@ -804,12 +772,6 @@ impl ControlLoop {
         ry: f64,
         rz: f64,
     ) -> Result<(), &'static str> {
-        // TODO: Need to implement the calculation of meter-to-step for 78
-        // actuators.
-        if !self.is_simulation_mode() {
-            panic!("Not implemented yet.");
-        }
-
         if self._mode != ClosedLoopControlMode::ClosedLoop {
             return Err("The control loop needs to be in closed-loop mode.");
         }
@@ -832,14 +794,13 @@ impl ControlLoop {
             rz * arcsec_to_rad,
         );
 
-        let current_hardpoint_displacement = self.get_current_hardpoint_displacement();
         let hardpoints_displacement: Vec<f64> = config
             .hardpoints
             .iter()
             .enumerate()
             .map(|(idx, hp)| {
                 displacments_xyz[*hp] + config.disp_hardpoint_home[idx]
-                    - current_hardpoint_displacement[idx]
+                    - self._current_hardpoint_displacement[idx]
             })
             .collect();
 
@@ -876,18 +837,14 @@ impl ControlLoop {
             return Err("The control loop needs to be in closed-loop mode.");
         }
 
-        self.telemetry
-            .forces
-            .insert(String::from("applied"), force.to_vec());
+        self.applied_force = force.to_vec();
 
         Ok(())
     }
 
     /// Reset the applied force.
     pub fn reset_force(&mut self) {
-        self.telemetry
-            .forces
-            .insert(String::from("applied"), vec![0.0; NUM_ACTUATOR]);
+        self.applied_force = vec![0.0; NUM_ACTUATOR];
     }
 
     /// Move the actuators under the open-loop control.
@@ -927,69 +884,6 @@ impl ControlLoop {
             CommandActuator::Resume => self._open_loop.resume(),
         }
     }
-
-    /// Set the mode of the inner-loop controller (ILC).
-    ///
-    /// # Arguments
-    /// * `address` - The address of ILC.
-    /// * `mode` - The mode to be set.
-    ///
-    /// # Returns
-    /// Ok if the mode is set successfully. Otherwise, an error message.
-    pub fn set_ilc_mode(
-        &mut self,
-        address: usize,
-        mode: InnerLoopControlMode,
-    ) -> Result<InnerLoopControlMode, &'static str> {
-        if self._mode != ClosedLoopControlMode::Idle {
-            return Err("The control loop needs to be in idle mode.");
-        }
-
-        if self.is_simulation_mode() {
-            if let Some(plant) = &mut self.plant {
-                let new_mode = plant.set_ilc_mode(address, mode);
-                self.event_queue
-                    .add_event(Event::get_message_inner_loop_control_mode(
-                        address, new_mode,
-                    ));
-
-                return Ok(new_mode);
-            }
-        } else {
-            // Update the hardware.
-            panic!("Not implemented yet.");
-        }
-
-        Ok(InnerLoopControlMode::Unknown)
-    }
-
-    /// Get the mode of the inner-loop controller (ILC).
-    ///
-    /// # Arguments
-    /// * `address` - The address of ILC.
-    ///
-    /// # Returns
-    /// OK if the mode is retrieved successfully. Otherwise, an error message.
-    pub fn get_ilc_mode(&mut self, address: usize) -> Result<InnerLoopControlMode, &'static str> {
-        if self._mode != ClosedLoopControlMode::Idle {
-            return Err("The control loop needs to be in idle mode.");
-        }
-
-        if self.is_simulation_mode() {
-            if let Some(plant) = &self.plant {
-                let mode = plant.get_ilc_mode(address);
-                self.event_queue
-                    .add_event(Event::get_message_inner_loop_control_mode(address, mode));
-
-                return Ok(mode);
-            }
-        } else {
-            // Update the hardware.
-            panic!("Not implemented yet.");
-        }
-
-        Ok(InnerLoopControlMode::Unknown)
-    }
 }
 
 #[cfg(test)]
@@ -999,7 +893,7 @@ mod tests {
     use serde_json::json;
 
     use crate::constants::NUM_TEMPERATURE_RING;
-    use crate::mock::mock_constants::{PLANT_TEMPERATURE_HIGH, PLANT_TEMPERATURE_LOW};
+    use crate::daq::data_acquisition::DataAcquisition;
     use crate::utility::assert_relative_eq_vector;
 
     const EPSILON: f64 = 1e-7;
@@ -1013,16 +907,68 @@ mod tests {
         ControlLoop::new(&config, false, is_simulation_mode)
     }
 
-    fn stabilize_control_loop(control_loop: &mut ControlLoop) {
-        steps(control_loop, 10, ClosedLoopControlMode::TelemetryOnly);
-        steps(control_loop, 30, ClosedLoopControlMode::ClosedLoop);
+    fn create_data_acquisition(is_simulation_mode: bool) -> DataAcquisition {
+        let mut data_acquisition = DataAcquisition::new(is_simulation_mode);
+
+        if is_simulation_mode {
+            data_acquisition.init_default_digital_output();
+        }
+
+        if let Some(plant) = &mut data_acquisition.plant {
+            plant.power_system_communication.is_power_on = true;
+        }
+
+        data_acquisition
     }
 
-    fn steps(control_loop: &mut ControlLoop, cycle_times: i32, mode: ClosedLoopControlMode) {
-        control_loop._mode = mode;
-        for _ in 0..cycle_times {
-            control_loop.step();
+    fn stabilize_control_loop(
+        control_loop: &mut ControlLoop,
+        data_acquisition: &mut DataAcquisition,
+    ) -> TelemetryControlLoop {
+        steps(
+            control_loop,
+            data_acquisition,
+            10,
+            ClosedLoopControlMode::TelemetryOnly,
+        );
+
+        loop {
+            let telemetry = steps(
+                control_loop,
+                data_acquisition,
+                1,
+                ClosedLoopControlMode::ClosedLoop,
+            );
+            if telemetry.is_in_position {
+                return telemetry;
+            }
         }
+    }
+
+    fn steps(
+        control_loop: &mut ControlLoop,
+        data_acquisition: &mut DataAcquisition,
+        cycle_times: i32,
+        mode: ClosedLoopControlMode,
+    ) -> TelemetryControlLoop {
+        control_loop._mode = mode;
+
+        let mut telemetry = TelemetryControlLoop::new();
+        for _ in 0..cycle_times {
+            telemetry = data_acquisition.get_telemetry_ilc();
+            control_loop.process_telemetry_data(&mut telemetry);
+
+            control_loop.step(&mut telemetry);
+            if let Some(steps) = control_loop.take_steps_to_move_actuators() {
+                data_acquisition
+                    .plant
+                    .as_mut()
+                    .unwrap()
+                    .move_actuator_steps(&steps);
+            }
+        }
+
+        telemetry
     }
 
     #[test]
@@ -1037,9 +983,14 @@ mod tests {
         assert_eq!(config.step_limit["axial"], 40);
         assert_eq!(config.step_limit["tangent"], 40);
 
-        assert_eq!(control_loop.telemetry.inclinometer["raw"], 0.0);
+        assert_eq!(control_loop.external_elevation_angle, 0.0);
+        assert_eq!(control_loop.applied_force, vec![0.0; NUM_ACTUATOR]);
+        assert_eq!(
+            control_loop._current_hardpoint_displacement,
+            vec![0.0; NUM_HARDPOINTS]
+        );
 
-        assert!(control_loop.is_simulation_mode());
+        assert!(control_loop._is_simulation_mode);
     }
 
     #[test]
@@ -1137,106 +1088,132 @@ mod tests {
     }
 
     #[test]
-    fn test_is_simulation_mode_false() {
-        assert!(!create_control_loop(false).is_simulation_mode());
-    }
-
-    #[test]
     fn test_step_closed_loop() {
         let mut control_loop = create_control_loop(true);
         control_loop.config.enable_lut_temperature = true;
 
-        steps(&mut control_loop, 10, ClosedLoopControlMode::TelemetryOnly);
+        let mut data_acquisition = create_data_acquisition(true);
+
+        let mut telemetry = steps(
+            &mut control_loop,
+            &mut data_acquisition,
+            10,
+            ClosedLoopControlMode::TelemetryOnly,
+        );
 
         assert_relative_eq!(
-            control_loop.telemetry.forces["measured"][0],
+            telemetry.forces["measured"][0],
             216.2038167,
             epsilon = EPSILON
         );
 
         // In the initial beginning, the actuators are not in position.
-        steps(&mut control_loop, 1, ClosedLoopControlMode::ClosedLoop);
-        steps(&mut control_loop, 1, ClosedLoopControlMode::TelemetryOnly);
+        steps(
+            &mut control_loop,
+            &mut data_acquisition,
+            1,
+            ClosedLoopControlMode::ClosedLoop,
+        );
+        telemetry = steps(
+            &mut control_loop,
+            &mut data_acquisition,
+            1,
+            ClosedLoopControlMode::TelemetryOnly,
+        );
 
         assert_relative_eq!(
-            control_loop.telemetry.forces["measured"][0],
+            telemetry.forces["measured"][0],
             216.4099693,
             epsilon = EPSILON
         );
 
         // After some running of closed-loop control, the actuators are in
         // position.
-        steps(&mut control_loop, 30, ClosedLoopControlMode::ClosedLoop);
+        telemetry = steps(
+            &mut control_loop,
+            &mut data_acquisition,
+            30,
+            ClosedLoopControlMode::ClosedLoop,
+        );
 
         assert_relative_eq!(
-            control_loop.telemetry.forces["measured"][0],
+            telemetry.forces["measured"][0],
             190.5481269,
             epsilon = EPSILON
         );
     }
 
     #[test]
-    fn test_update_telemetry_data() {
-        let mut control_loop = create_control_loop(true);
-        control_loop.is_in_position = true;
-
-        control_loop.update_telemetry_data();
-
-        assert!(control_loop.telemetry.is_in_position);
-        assert_eq!(control_loop.telemetry.inclinometer["raw"], 90.0);
-
-        assert_relative_eq!(
-            control_loop.telemetry.forces["measured"][0],
-            216.2038166,
-            epsilon = EPSILON
-        );
-
-        assert_eq!(
-            control_loop.telemetry.temperature["ring"][0],
-            PLANT_TEMPERATURE_LOW
-        );
-        assert_eq!(
-            control_loop.telemetry.temperature["intake"][0],
-            PLANT_TEMPERATURE_LOW
-        );
-        assert_eq!(
-            control_loop.telemetry.temperature["exhaust"][0],
-            PLANT_TEMPERATURE_HIGH
-        );
-    }
-
-    #[test]
     fn test_process_telemetry_data() {
         let mut control_loop = create_control_loop(true);
-        control_loop.update_telemetry_data();
+        control_loop.is_in_position = true;
+        control_loop.external_elevation_angle = 10.0;
+        control_loop.applied_force = vec![5.0; NUM_ACTUATOR];
+
+        let mut data_acquisition = create_data_acquisition(true);
 
         // Let the hardpoints have the same positions as the home position.
+        let mut telemetry = data_acquisition.get_telemetry_ilc();
         control_loop
             .config
             .hardpoints
             .iter()
             .enumerate()
             .for_each(|(idx, hardpoint)| {
-                control_loop.telemetry.actuator_positions[*hardpoint] =
+                telemetry.actuator_positions[*hardpoint] =
                     control_loop.config.disp_hardpoint_home[idx] * 1e3;
             });
 
-        control_loop.process_telemetry_data();
+        control_loop.process_telemetry_data(&mut telemetry);
 
-        assert_eq!(control_loop.telemetry.inclinometer["processed"], 89.06);
-        assert_relative_eq!(
-            control_loop.telemetry.inclinometer["zenith"],
-            0.94,
-            epsilon = EPSILON
-        );
+        assert_eq!(telemetry.inclinometer["processed"], 89.06);
+        assert_relative_eq!(telemetry.inclinometer["zenith"], 0.94, epsilon = EPSILON);
 
-        for key in control_loop.telemetry.mirror_position.keys() {
+        for key in telemetry.mirror_position.keys() {
             assert_relative_eq!(
-                control_loop.telemetry.mirror_position[key],
-                control_loop.telemetry.mirror_position_ims[key],
+                telemetry.mirror_position[key],
+                telemetry.mirror_position_ims[key],
                 epsilon = EPSILON
             );
         }
+
+        assert!(telemetry.is_in_position);
+        assert_eq!(telemetry.inclinometer["external"], 10.0);
+        assert_eq!(telemetry.forces["applied"], vec![5.0; NUM_ACTUATOR]);
+    }
+
+    #[test]
+    fn test_update_hardpoint_correction_to_telemetry() {
+        let mut hardpoint_correction = vec![0.0; NUM_ACTUATOR];
+        hardpoint_correction[1..4]
+            .iter_mut()
+            .zip((1..4).into_iter())
+            .for_each(|(x, y)| {
+                *x = y as f64;
+            });
+        hardpoint_correction[NUM_AXIAL_ACTUATOR..NUM_ACTUATOR]
+            .iter_mut()
+            .zip((1..7).into_iter())
+            .for_each(|(x, y)| {
+                *x = y as f64;
+            });
+
+        let control_loop = create_control_loop(true);
+
+        let mut telemetry = TelemetryControlLoop::new();
+        control_loop
+            .update_hardpoint_correction_to_telemetry(&mut telemetry, &hardpoint_correction);
+
+        assert_eq!(
+            telemetry.forces["hardpointCorrection"],
+            hardpoint_correction
+        );
+
+        ["fx", "fy", "fz", "mx", "my", "mz"]
+            .iter()
+            .for_each(|axis| {
+                assert!(telemetry.force_balance[*axis] != 0.0);
+            });
     }
 
     #[test]
@@ -1291,14 +1268,11 @@ mod tests {
     fn test_calculate_tangent_force_error() {
         let zenit_angle = 90.0 - correct_inclinometer_angle(89.853, 0.94);
 
-        let mut control_loop = create_control_loop(true);
-        control_loop
-            .telemetry
-            .inclinometer
-            .insert("zenith".to_string(), zenit_angle);
-        let tangent_force_error = control_loop.calculate_tangent_force_error(&vec![
-            -325.307, -447.377, 1128.37, -1249.98, 458.63, 267.627,
-        ]);
+        let control_loop = create_control_loop(true);
+        let tangent_force_error = control_loop.calculate_tangent_force_error(
+            &vec![-325.307, -447.377, 1128.37, -1249.98, 458.63, 267.627],
+            zenit_angle,
+        );
 
         assert_relative_eq_vector(
             &tangent_force_error,
@@ -1317,12 +1291,15 @@ mod tests {
     }
 
     #[test]
-    fn test_get_current_hardpoint_displacement() {
+    fn test_set_current_hardpoint_displacement() {
         let mut control_loop = create_control_loop(true);
-        control_loop.telemetry.actuator_positions = (0..NUM_ACTUATOR).map(|x| x as f64).collect();
+        let actuator_positions: Vec<f64> = (0..NUM_ACTUATOR).map(|x| x as f64).collect();
 
-        let displacement = control_loop.get_current_hardpoint_displacement();
-        assert_eq!(displacement, vec![0.005, 0.015, 0.025, 0.073, 0.075, 0.077]);
+        control_loop.set_current_hardpoint_displacement(&actuator_positions);
+        assert_eq!(
+            control_loop._current_hardpoint_displacement,
+            vec![0.005, 0.015, 0.025, 0.073, 0.075, 0.077]
+        );
     }
 
     #[test]
@@ -1366,25 +1343,26 @@ mod tests {
     fn test_handle_position_mirror_closed_loop() {
         // Stabilize the mirror first
         let mut control_loop = create_control_loop(true);
-        stabilize_control_loop(&mut control_loop);
-        control_loop._mode = ClosedLoopControlMode::ClosedLoop;
+        let mut data_acquisition = create_data_acquisition(true);
+        stabilize_control_loop(&mut control_loop, &mut data_acquisition);
 
         // Position the mirror
         let _ = control_loop.handle_position_mirror(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
-        steps(&mut control_loop, 220, ClosedLoopControlMode::ClosedLoop);
+        let telemetry = steps(
+            &mut control_loop,
+            &mut data_acquisition,
+            220,
+            ClosedLoopControlMode::ClosedLoop,
+        );
 
         assert_eq!(control_loop.steps_position_mirror, vec![0; NUM_ACTUATOR]);
 
         let axes = ["x", "y", "z", "xRot", "yRot", "zRot"];
         axes.iter().enumerate().for_each(|(idx, axis)| {
             let position = idx as f64 + 1.0;
+            assert_relative_eq!(telemetry.mirror_position[*axis], position, epsilon = 1e-1);
             assert_relative_eq!(
-                control_loop.telemetry.mirror_position[*axis],
-                position,
-                epsilon = 1e-1
-            );
-            assert_relative_eq!(
-                control_loop.telemetry.mirror_position_ims[*axis],
+                telemetry.mirror_position_ims[*axis],
                 position,
                 epsilon = 1e-1
             );
@@ -1410,31 +1388,124 @@ mod tests {
         let force = vec![10.0; NUM_ACTUATOR];
         assert_eq!(control_loop.apply_force(&force), Ok(()));
 
-        assert_relative_eq_vector(&control_loop.telemetry.forces["applied"], &force, EPSILON);
+        assert_relative_eq_vector(&control_loop.applied_force, &force, EPSILON);
     }
 
     #[test]
     fn test_apply_force_closed_loop() {
         // Stabilize the mirror first
         let mut control_loop = create_control_loop(true);
-        stabilize_control_loop(&mut control_loop);
+        let mut data_acquisition = create_data_acquisition(true);
+        let mut telemetry = stabilize_control_loop(&mut control_loop, &mut data_acquisition);
 
-        let force_original = control_loop.telemetry.forces["measured"][3];
+        let force_original = telemetry.forces["measured"][3];
 
         // Apply the force
         let mut force = vec![0.0; NUM_ACTUATOR];
         force[3] = 5.0;
         let _ = control_loop.apply_force(&force);
 
-        steps(&mut control_loop, 15, ClosedLoopControlMode::ClosedLoop);
+        telemetry = stabilize_control_loop(&mut control_loop, &mut data_acquisition);
 
-        let force_updated = control_loop.telemetry.forces["measured"][3];
+        let force_updated = telemetry.forces["measured"][3];
 
         assert_relative_eq!(
             force_updated - force_original,
-            4.53263384,
+            4.55580783,
             epsilon = EPSILON
         );
+    }
+
+    #[test]
+    fn test_apply_force_closed_loop_and_check_calculation_and_stability() {
+        // Stabilize the mirror first
+        let mut control_loop = create_control_loop(true);
+        let mut data_acquisition = create_data_acquisition(true);
+        let mut telemetry = stabilize_control_loop(&mut control_loop, &mut data_acquisition);
+
+        assert_relative_eq_vector(
+            &telemetry.forces["hardpointCorrection"][0..5],
+            &vec![
+                -6.38991131,
+                -6.34897354,
+                -6.27481481,
+                -6.17066679,
+                -6.04108298,
+            ],
+            EPSILON,
+        );
+
+        // Apply the force
+        let mut force = vec![0.0; NUM_ACTUATOR];
+        force[3] = 100.0;
+        let _ = control_loop.apply_force(&force);
+
+        telemetry = stabilize_control_loop(&mut control_loop, &mut data_acquisition);
+
+        let expected_hardpoint_correction_force = vec![
+            -10.87706161,
+            -11.19361034,
+            -11.33033979,
+            -11.28121744,
+            -11.04842581,
+        ];
+        assert_relative_eq_vector(
+            &telemetry.forces["hardpointCorrection"][0..5],
+            &expected_hardpoint_correction_force,
+            EPSILON,
+        );
+
+        // Check the stability by running more cycles
+        for _ in 0..100 {
+            telemetry = steps(
+                &mut control_loop,
+                &mut data_acquisition,
+                1,
+                ClosedLoopControlMode::ClosedLoop,
+            );
+
+            assert!(telemetry.is_in_position);
+            assert_relative_eq_vector(
+                &telemetry.forces["hardpointCorrection"][0..5],
+                &expected_hardpoint_correction_force,
+                EPSILON,
+            );
+        }
+
+        // Reset the force
+        let _ = control_loop.reset_force();
+
+        telemetry = stabilize_control_loop(&mut control_loop, &mut data_acquisition);
+
+        let expected_hardpoint_correction_reset = vec![
+            -6.37788502,
+            -6.32490499,
+            -6.24109329,
+            -6.13010428,
+            -5.99678962,
+        ];
+        assert_relative_eq_vector(
+            &telemetry.forces["hardpointCorrection"][0..5],
+            &expected_hardpoint_correction_reset,
+            EPSILON,
+        );
+
+        // Check the stability by running more cycles
+        for _ in 0..100 {
+            telemetry = steps(
+                &mut control_loop,
+                &mut data_acquisition,
+                1,
+                ClosedLoopControlMode::ClosedLoop,
+            );
+
+            assert!(telemetry.is_in_position);
+            assert_relative_eq_vector(
+                &telemetry.forces["hardpointCorrection"][0..5],
+                &expected_hardpoint_correction_reset,
+                EPSILON,
+            );
+        }
     }
 
     #[test]
@@ -1444,16 +1515,14 @@ mod tests {
 
         control_loop.reset_force();
 
-        assert_eq!(
-            control_loop.telemetry.forces["applied"],
-            vec![0.0; NUM_ACTUATOR]
-        );
+        assert_eq!(control_loop.applied_force, vec![0.0; NUM_ACTUATOR]);
     }
 
     #[test]
     fn test_move_actuators() {
         let mut control_loop = create_control_loop(true);
-        stabilize_control_loop(&mut control_loop);
+        let mut data_acquisition = create_data_acquisition(true);
+        let mut telemetry = stabilize_control_loop(&mut control_loop, &mut data_acquisition);
 
         // Should fail if not in open-loop mode
         assert_eq!(
@@ -1470,7 +1539,7 @@ mod tests {
         control_loop._mode = ClosedLoopControlMode::OpenLoop;
 
         // Get the initial actuator step
-        let step_init = control_loop.telemetry.actuator_steps[1];
+        let step_init = telemetry.actuator_steps[1];
 
         // Start the movement
         assert_eq!(
@@ -1484,12 +1553,19 @@ mod tests {
         );
 
         // Use the telemetry only mode to get the updated data of plant
-        control_loop._mode = ClosedLoopControlMode::OpenLoop;
-        control_loop.step();
-
-        control_loop._mode = ClosedLoopControlMode::TelemetryOnly;
-        control_loop.step();
-        let step_move = control_loop.telemetry.actuator_steps[1];
+        steps(
+            &mut control_loop,
+            &mut data_acquisition,
+            1,
+            ClosedLoopControlMode::OpenLoop,
+        );
+        telemetry = steps(
+            &mut control_loop,
+            &mut data_acquisition,
+            1,
+            ClosedLoopControlMode::TelemetryOnly,
+        );
+        let step_move = telemetry.actuator_steps[1];
 
         assert_eq!(
             step_move - step_init,
@@ -1508,12 +1584,19 @@ mod tests {
             Ok(())
         );
 
-        control_loop._mode = ClosedLoopControlMode::OpenLoop;
-        control_loop.step();
-
-        control_loop._mode = ClosedLoopControlMode::TelemetryOnly;
-        control_loop.step();
-        let step_pause = control_loop.telemetry.actuator_steps[1];
+        steps(
+            &mut control_loop,
+            &mut data_acquisition,
+            1,
+            ClosedLoopControlMode::OpenLoop,
+        );
+        telemetry = steps(
+            &mut control_loop,
+            &mut data_acquisition,
+            1,
+            ClosedLoopControlMode::TelemetryOnly,
+        );
+        let step_pause = telemetry.actuator_steps[1];
 
         assert_eq!(step_pause, step_move);
 
@@ -1529,12 +1612,19 @@ mod tests {
             Ok(())
         );
 
-        control_loop._mode = ClosedLoopControlMode::OpenLoop;
-        control_loop.step();
-
-        control_loop._mode = ClosedLoopControlMode::TelemetryOnly;
-        control_loop.step();
-        let step_resume = control_loop.telemetry.actuator_steps[1];
+        steps(
+            &mut control_loop,
+            &mut data_acquisition,
+            1,
+            ClosedLoopControlMode::OpenLoop,
+        );
+        telemetry = steps(
+            &mut control_loop,
+            &mut data_acquisition,
+            1,
+            ClosedLoopControlMode::TelemetryOnly,
+        );
+        let step_resume = telemetry.actuator_steps[1];
 
         assert_eq!(step_resume - step_pause, 20);
         assert!(!control_loop._open_loop.is_running);
@@ -1551,67 +1641,20 @@ mod tests {
             Ok(())
         );
 
-        control_loop._mode = ClosedLoopControlMode::OpenLoop;
-        control_loop.step();
-
-        control_loop._mode = ClosedLoopControlMode::TelemetryOnly;
-        control_loop.step();
-        let step_stop = control_loop.telemetry.actuator_steps[1];
+        steps(
+            &mut control_loop,
+            &mut data_acquisition,
+            1,
+            ClosedLoopControlMode::OpenLoop,
+        );
+        telemetry = steps(
+            &mut control_loop,
+            &mut data_acquisition,
+            1,
+            ClosedLoopControlMode::TelemetryOnly,
+        );
+        let step_stop = telemetry.actuator_steps[1];
 
         assert_eq!(step_stop, step_resume);
-    }
-
-    #[test]
-    fn test_set_ilc_mode() {
-        let mut control_loop = create_control_loop(true);
-
-        // Should succeed to set the mode when in idle mode
-        assert_eq!(
-            control_loop
-                .set_ilc_mode(10, InnerLoopControlMode::Disabled)
-                .unwrap(),
-            InnerLoopControlMode::Disabled
-        );
-        assert_eq!(
-            control_loop.event_queue.get_events_and_clear(),
-            vec![json!({
-                "id": "innerLoopControlMode",
-                "address": 10,
-                "mode": 2,
-            })]
-        );
-
-        // Should fail to set the mode when not in idle mode
-        control_loop._mode = ClosedLoopControlMode::ClosedLoop;
-        assert_eq!(
-            control_loop.set_ilc_mode(10, InnerLoopControlMode::Standby),
-            Err("The control loop needs to be in idle mode.")
-        );
-    }
-
-    #[test]
-    fn test_get_ilc_mode() {
-        let mut control_loop = create_control_loop(true);
-
-        // Should succeed to set the mode when in idle mode
-        assert_eq!(
-            control_loop.get_ilc_mode(10).unwrap(),
-            InnerLoopControlMode::Standby
-        );
-        assert_eq!(
-            control_loop.event_queue.get_events_and_clear(),
-            vec![json!({
-                "id": "innerLoopControlMode",
-                "address": 10,
-                "mode": 1,
-            })]
-        );
-
-        // Should fail to set the mode when not in idle mode
-        control_loop._mode = ClosedLoopControlMode::ClosedLoop;
-        assert_eq!(
-            control_loop.get_ilc_mode(10),
-            Err("The control loop needs to be in idle mode.")
-        );
     }
 }

--- a/src/control/control_loop_process.rs
+++ b/src/control/control_loop_process.rs
@@ -19,23 +19,22 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use log::info;
-use serde_json::Value;
+use log::{error, info};
+use serde_json::{json, Value};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     mpsc::{sync_channel, Receiver, SyncSender},
     Arc,
 };
-use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 use crate::command::{
     command_control_loop::{
-        CommandApplyForces, CommandGetInnerLoopControlMode, CommandMoveActuators,
-        CommandPositionMirror, CommandResetActuatorSteps, CommandResetForceOffsets,
-        CommandSetClosedLoopControlMode, CommandSetConfig, CommandSetExternalElevation,
-        CommandSetInnerLoopControlMode,
+        CommandApplyForces, CommandMoveActuators, CommandPositionMirror, CommandResetActuatorSteps,
+        CommandResetForceOffsets, CommandSetClosedLoopControlMode, CommandSetConfig,
+        CommandSetExternalElevation,
     },
+    command_data_acquisition::CommandMoveActuatorSteps,
     command_schema::{Command, CommandSchema},
 };
 use crate::config::Config;
@@ -126,8 +125,6 @@ impl ControlLoopProcess {
         command_schema.add_command(Box::new(CommandMoveActuators));
         command_schema.add_command(Box::new(CommandSetConfig));
         command_schema.add_command(Box::new(CommandSetExternalElevation));
-        command_schema.add_command(Box::new(CommandGetInnerLoopControlMode));
-        command_schema.add_command(Box::new(CommandSetInnerLoopControlMode));
 
         command_schema
     }
@@ -156,9 +153,22 @@ impl ControlLoopProcess {
         let telemetry_command_name = CommandSetExternalElevation.name();
 
         let period = (1000.0 / self.control_loop.config.control_frequency) as u64;
+        let mut seq_id_move_actuator_steps = 0;
+        let mut processed_telemetry: Option<TelemetryControlLoop> = None;
         while !self._stop.load(Ordering::Relaxed) {
             // Time the control loop
             let now = Instant::now();
+
+            // Process the received telemetry from the data acquisition.
+            if let Some(telemetry) = &mut processed_telemetry {
+                // We need to check the sequence ID here because we need to
+                // make sure the new telemetry is the expected one that the
+                // inner-loop controlloer (ILC) has moved the actuators.
+                if telemetry.seq_id_move_actuator_steps == seq_id_move_actuator_steps {
+                    self.control_loop.process_telemetry_data(telemetry);
+                    self.control_loop.step(telemetry);
+                }
+            }
 
             // Process the messages.
             let mut command_result = None;
@@ -197,13 +207,27 @@ impl ControlLoopProcess {
                 command_result = None;
             }
 
-            // Run the control loop
-            self.control_loop.step();
+            if let Some(steps) = self.control_loop.take_steps_to_move_actuators() {
+                seq_id_move_actuator_steps =
+                    self.get_next_seq_id_move_actuator_steps(seq_id_move_actuator_steps);
+                if self
+                    ._sender_to_daq
+                    .try_send(json!({
+                        "id": CommandMoveActuatorSteps.name(),
+                        "seq_id_move_actuator_steps": seq_id_move_actuator_steps,
+                        "steps": steps,
+                    }))
+                    .is_err()
+                {
+                    error!(
+                        "Failed to send the move actuator steps command to the data acquisition with sequence ID {}.",
+                        seq_id_move_actuator_steps
+                    );
+                };
+            }
 
             // Send the telemetry and event data to the model and ignore the
             // error.
-            let mut telemetry = self.control_loop.telemetry.clone();
-
             let events = if self.control_loop.event_queue.has_event() {
                 Some(self.control_loop.event_queue.get_events_and_clear())
             } else {
@@ -211,22 +235,49 @@ impl ControlLoopProcess {
             };
 
             let cycle_time = now.elapsed().as_millis() as u64;
-            telemetry.cycle_time = (cycle_time as f64) / 1000.0;
+
+            if let Some(telemetry) = &mut processed_telemetry {
+                telemetry.cycle_time = (cycle_time as f64) / 1000.0;
+            }
 
             let _ = self._sender_to_model.try_send(Telemetry::new(
                 None,
-                Some(telemetry),
+                processed_telemetry.take(),
                 command_result,
                 events,
             ));
 
-            // Sleep with the remaining time
-            if period > cycle_time {
-                sleep(Duration::from_millis(period - cycle_time));
+            // Calculate the remaining time to wait for the new telemetry.
+            let wait_telemetry_time = period.saturating_sub(cycle_time);
+            match self
+                ._receiver_telemetry_to_control_loop
+                .recv_timeout(Duration::from_millis(wait_telemetry_time))
+            {
+                Ok(telemetry) => {
+                    processed_telemetry = Some(telemetry);
+                }
+                Err(_) => {
+                    processed_telemetry = None;
+                }
             }
         }
 
         info!("Control loop is stopped.");
+    }
+
+    /// Get the next sequence ID for the move actuator steps command.
+    ///
+    /// # Arguments
+    /// * `current_id` - The current sequence ID.
+    ///
+    /// # Returns
+    /// The next sequence ID.
+    fn get_next_seq_id_move_actuator_steps(&self, current_id: i32) -> i32 {
+        if current_id == i32::MAX {
+            0
+        } else {
+            current_id + 1
+        }
     }
 }
 
@@ -236,11 +287,22 @@ mod tests {
 
     use serde_json::json;
     use std::path::Path;
-    use std::thread::spawn;
+    use std::thread::{sleep, spawn};
 
+    use crate::command::command_control_loop::{
+        CommandMoveActuators, CommandSetClosedLoopControlMode,
+    };
     use crate::daq::data_acquisition_process::DataAcquisitionProcess;
+    use crate::enums::DataAcquisitionMode;
+    use crate::mock::mock_constants::PLANT_STEP_TO_ENCODER;
+    use crate::telemetry::telemetry_power::TelemetryPower;
 
-    fn create_control_loop_process() -> (ControlLoopProcess, Receiver<Telemetry>, Receiver<Value>) {
+    fn create_control_loop_process() -> (
+        ControlLoopProcess,
+        Receiver<Telemetry>,
+        SyncSender<Value>,
+        Receiver<Value>,
+    ) {
         let config = Config::new(
             Path::new("config/parameters_control.yaml"),
             Path::new("config/lut/handling"),
@@ -262,7 +324,32 @@ mod tests {
                 &stop,
             ),
             receiver_to_model,
+            sender_to_daq,
             receiver_to_daq,
+        )
+    }
+
+    fn create_data_acquisition_process(
+        sender_telemetry_to_control_loop: &SyncSender<TelemetryControlLoop>,
+        sender_to_model: &SyncSender<Telemetry>,
+        sender_to_daq: SyncSender<Value>,
+        receiver_to_daq: Receiver<Value>,
+        stop: &Arc<AtomicBool>,
+    ) -> (DataAcquisitionProcess, Receiver<TelemetryPower>) {
+        let (sender_telemetry_to_power, receiver_telemetry_to_power) =
+            sync_channel(BOUND_SYNC_CHANNEL);
+
+        (
+            DataAcquisitionProcess::new(
+                true,
+                sender_telemetry_to_control_loop,
+                &sender_telemetry_to_power,
+                sender_to_model,
+                sender_to_daq,
+                receiver_to_daq,
+                stop,
+            ),
+            receiver_telemetry_to_power,
         )
     }
 
@@ -270,42 +357,61 @@ mod tests {
     fn test_new() {
         let control_loop_process = create_control_loop_process().0;
 
-        assert_eq!(
-            control_loop_process._command_schema.number_of_commands(),
-            10
-        );
+        assert_eq!(control_loop_process._command_schema.number_of_commands(), 8);
     }
 
     #[test]
     fn test_run() {
-        let (mut control_loop_process, receiver_to_model, _receiver_to_daq) =
+        let (mut control_loop_process, receiver_to_model, sender_to_daq, receiver_to_daq) =
             create_control_loop_process();
         let stop = control_loop_process._stop.clone();
 
+        let (mut data_acquisition_process, _receiver_telemetry_power) =
+            create_data_acquisition_process(
+                &control_loop_process._sender_telemetry_to_control_loop,
+                &control_loop_process._sender_to_model,
+                sender_to_daq,
+                receiver_to_daq,
+                &stop,
+            );
+        data_acquisition_process.daq.mode = DataAcquisitionMode::Telemetry;
+        if let Some(plant) = &mut data_acquisition_process.daq.plant {
+            plant.power_system_communication.is_power_on = true;
+        }
+
         let sender_to_control_loop = control_loop_process.get_sender_to_control_loop();
 
-        let handle = spawn(move || {
+        let handle_control_loop = spawn(move || {
             control_loop_process.run();
+        });
+        let handle_data_acquisition = spawn(move || {
+            data_acquisition_process.run();
         });
 
         sleep(Duration::from_millis(500));
 
         // Set the closed-loop control mode.
         let _ = sender_to_control_loop.try_send(json!({
-            "id": "cmd_setClosedLoopControlMode",
+            "id": CommandSetClosedLoopControlMode.name(),
             "sequence_id": 2,
-            "mode": 2,
+            "mode": 3,
         }));
 
         // Check the telemetry data.
-        sleep(Duration::from_millis(500));
-
         let mut latest_telemetry = Telemetry::new(None, None, None, None);
         loop {
-            match receiver_to_model.try_recv() {
-                Ok(telemetry) => {
-                    if let Some(_result) = &telemetry.command_result {
-                        latest_telemetry = telemetry;
+            match receiver_to_model.recv_timeout(Duration::from_millis(50)) {
+                Ok(mut telemetry) => {
+                    if telemetry.control_loop.is_some() {
+                        latest_telemetry.control_loop = telemetry.control_loop.take();
+                    }
+
+                    if telemetry.events.is_some() {
+                        latest_telemetry.events = telemetry.events.take();
+                    }
+
+                    if telemetry.command_result.is_some() {
+                        latest_telemetry.command_result = telemetry.command_result.take();
                         break;
                     }
                 }
@@ -327,7 +433,7 @@ mod tests {
             vec![
                 json!({
                     "id": "closedLoopControlMode",
-                    "mode": 2,
+                    "mode": 3,
                 }),
                 json!({
                     "id": "forceBalanceSystemStatus",
@@ -336,9 +442,59 @@ mod tests {
             ]
         );
 
+        let mut telemetry_control_loop = latest_telemetry.control_loop.unwrap();
+
+        assert_eq!(telemetry_control_loop.seq_id_move_actuator_steps, 0);
+        assert_eq!(telemetry_control_loop.inclinometer["raw"], 90.0);
+
+        // Move the actuator steps.
+        let _ = sender_to_control_loop.try_send(json!({
+            "id": CommandMoveActuators.name(),
+            "sequence_id": 3,
+            "actuatorCommand": 1,
+            "actuators": [0, 1, 2],
+            "displacement": 80,
+            "unit": 2,
+        }));
+
+        let expected_encoder_value = (80.0 * PLANT_STEP_TO_ENCODER) as i32;
+        loop {
+            if let Ok(mut telemetry) = receiver_to_model.recv_timeout(Duration::from_millis(50)) {
+                if let Some(control_loop) = &telemetry.control_loop {
+                    if control_loop.ilc_encoders[0] == expected_encoder_value {
+                        latest_telemetry.control_loop = telemetry.control_loop.take();
+                        break;
+                    }
+                }
+            }
+        }
+
+        telemetry_control_loop = latest_telemetry.control_loop.unwrap();
+
+        assert!(telemetry_control_loop.seq_id_move_actuator_steps > 0);
+        assert_eq!(
+            telemetry_control_loop.ilc_encoders[0],
+            expected_encoder_value,
+        );
+
         // Close the server.
         stop.store(true, Ordering::Relaxed);
 
-        assert!(handle.join().is_ok());
+        assert!(handle_control_loop.join().is_ok());
+        assert!(handle_data_acquisition.join().is_ok());
+    }
+
+    #[test]
+    fn test_get_next_seq_id_move_actuator_steps() {
+        let control_loop_process = create_control_loop_process().0;
+
+        assert_eq!(
+            control_loop_process.get_next_seq_id_move_actuator_steps(0),
+            1
+        );
+        assert_eq!(
+            control_loop_process.get_next_seq_id_move_actuator_steps(i32::MAX),
+            0
+        );
     }
 }

--- a/src/control/lut.rs
+++ b/src/control/lut.rs
@@ -190,8 +190,8 @@ impl Lut {
     pub fn get_lut_forces(
         &self,
         lut_angle: f64,
-        ring_temperature: &Vec<f64>,
-        ref_temperature: &Vec<f64>,
+        ring_temperature: &[f64],
+        ref_temperature: &[f64],
         enable_lut_temperature: bool,
     ) -> (Vec<f64>, Vec<f64>) {
         let (forces_gravity, mut forces_temperature) = Self::calc_look_up_forces(
@@ -231,13 +231,13 @@ impl Lut {
     /// # Returns
     /// A tuple of two vectors: gravity correction forces and temperature
     /// correction forces in Newton.
-    #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
+    #[allow(clippy::too_many_arguments)]
     fn calc_look_up_forces(
         lut_angle: f64,
-        ref_angles: &Vec<f64>,
+        ref_angles: &[f64],
         lut_gravity: &SMatrix<f64, NUM_ACTUATOR, NUM_COLUMN_LUT_GRAVITY>,
-        ring_temperature: &Vec<f64>,
-        ref_temperature: &Vec<f64>,
+        ring_temperature: &[f64],
+        ref_temperature: &[f64],
         temp_inv: &SMatrix<f64, NUM_LUT_TEMPERATURE, NUM_TEMPERATURE_RING>,
         lut_temperature: &SMatrix<f64, NUM_AXIAL_ACTUATOR, NUM_LUT_TEMPERATURE>,
         enable_lut_temperature: bool,
@@ -252,7 +252,7 @@ impl Lut {
         let (reordered_temperatures, reordered_ref_temperature) = order
             .iter()
             .map(|idx| (ring_temperature[*idx], ref_temperature[*idx]))
-            .unzip();
+            .unzip::<f64, f64, Vec<f64>, Vec<f64>>();
 
         let forces_temperature: Vec<f64> = Self::calc_look_up_forces_temperature(
             &reordered_temperatures,
@@ -281,10 +281,9 @@ impl Lut {
     ///
     /// # Returns
     /// Temperature correction force in Newton.
-    #[allow(clippy::ptr_arg)]
     fn calc_look_up_forces_temperature(
-        temperature: &Vec<f64>,
-        ref_temperature: &Vec<f64>,
+        temperature: &[f64],
+        ref_temperature: &[f64],
         temp_inv: &SMatrix<f64, NUM_LUT_TEMPERATURE, NUM_TEMPERATURE_RING>,
         lut: &SMatrix<f64, NUM_AXIAL_ACTUATOR, NUM_LUT_TEMPERATURE>,
     ) -> Vec<f64> {

--- a/src/control/open_loop.rs
+++ b/src/control/open_loop.rs
@@ -26,6 +26,7 @@ use crate::control::actuator::Actuator;
 use crate::control::math_tool::clip;
 use crate::enums::ActuatorDisplacementUnit;
 
+#[derive(Default)]
 pub struct OpenLoop {
     // The open-loop control is running or not.
     pub is_running: bool,
@@ -35,19 +36,14 @@ pub struct OpenLoop {
     _selected_actuators: Vec<usize>,
     // Displacement of steps to do the movement.
     _displacement_steps: Vec<i32>,
-    // Is the simulation mode enabled or not.
-    _is_simulation_mode: bool,
 }
 
 impl OpenLoop {
     /// Open-loop control.
     ///
-    /// # Arguments
-    /// * `is_simulation_mode` - Enable the simulation mode or not.
-    ///
     /// # Returns
     /// A new OpenLoop object.
-    pub fn new(is_simulation_mode: bool) -> Self {
+    pub fn new() -> Self {
         Self {
             is_running: false,
             actuators: Actuator::from_cell_mapping_file(Path::new(
@@ -55,7 +51,6 @@ impl OpenLoop {
             )),
             _selected_actuators: Vec::new(),
             _displacement_steps: Vec::new(),
-            _is_simulation_mode: is_simulation_mode,
         }
     }
 
@@ -107,19 +102,12 @@ impl OpenLoop {
     ///
     /// # Returns
     /// Steps of displacement.
-    ///
-    /// # Panics
-    /// If the simulation mode is disabled.
     fn calculate_steps(
         &self,
         actuators: &[usize],
         displacement: f64,
         unit: ActuatorDisplacementUnit,
     ) -> Vec<i32> {
-        if !self._is_simulation_mode {
-            panic!("Not implemented yet.");
-        }
-
         if unit == ActuatorDisplacementUnit::Millimeter {
             actuators
                 .iter()
@@ -242,13 +230,13 @@ impl OpenLoop {
 mod tests {
     use super::*;
 
-    fn create_open_loop(is_simulation_mode: bool) -> OpenLoop {
-        OpenLoop::new(is_simulation_mode)
+    fn create_open_loop() -> OpenLoop {
+        OpenLoop::new()
     }
 
     #[test]
     fn test_start_fail() {
-        let mut open_loop = create_open_loop(true);
+        let mut open_loop = create_open_loop();
 
         assert_eq!(
             open_loop.start(&Vec::new(), 10.0, ActuatorDisplacementUnit::Millimeter),
@@ -269,7 +257,7 @@ mod tests {
 
     #[test]
     fn test_start_success() {
-        let mut open_loop = create_open_loop(true);
+        let mut open_loop = create_open_loop();
 
         assert_eq!(
             open_loop.start(&vec![1], 2.0, ActuatorDisplacementUnit::Step),
@@ -282,7 +270,7 @@ mod tests {
 
     #[test]
     fn test_calculate_steps() {
-        let open_loop = create_open_loop(true);
+        let open_loop = create_open_loop();
 
         let idx = 1;
         assert_eq!(
@@ -302,7 +290,7 @@ mod tests {
 
     #[test]
     fn test_stop() {
-        let mut open_loop = create_open_loop(true);
+        let mut open_loop = create_open_loop();
         open_loop.is_running = true;
         open_loop._selected_actuators = vec![10];
         open_loop._displacement_steps = vec![10];
@@ -316,7 +304,7 @@ mod tests {
 
     #[test]
     fn test_pause() {
-        let mut open_loop = create_open_loop(true);
+        let mut open_loop = create_open_loop();
         open_loop.is_running = true;
 
         open_loop.pause();
@@ -326,14 +314,14 @@ mod tests {
 
     #[test]
     fn test_resume_fail() {
-        let mut open_loop = create_open_loop(true);
+        let mut open_loop = create_open_loop();
 
         assert_eq!(open_loop.resume(), Err("The movement is done."));
     }
 
     #[test]
     fn test_resume_success() {
-        let mut open_loop = create_open_loop(true);
+        let mut open_loop = create_open_loop();
         open_loop._displacement_steps = vec![10];
 
         assert_eq!(open_loop.resume(), Ok(()));
@@ -342,7 +330,7 @@ mod tests {
 
     #[test]
     fn test_get_steps_to_move_fail() {
-        let mut open_loop = create_open_loop(true);
+        let mut open_loop = create_open_loop();
 
         assert_eq!(
             open_loop.get_steps_to_move(1, 2),
@@ -362,7 +350,7 @@ mod tests {
 
     #[test]
     fn test_get_steps_to_move_done() {
-        let mut open_loop = create_open_loop(true);
+        let mut open_loop = create_open_loop();
         let _ = open_loop.start(&vec![1, 74], -2.0, ActuatorDisplacementUnit::Step);
 
         let actuator_steps = open_loop.get_steps_to_move(3, 3).unwrap();
@@ -374,7 +362,7 @@ mod tests {
 
     #[test]
     fn test_run_steps_not_done() {
-        let mut open_loop = create_open_loop(true);
+        let mut open_loop = create_open_loop();
         let _ = open_loop.start(&vec![1, 73], 4.0, ActuatorDisplacementUnit::Step);
 
         let actuator_steps = open_loop.get_steps_to_move(2, 3).unwrap();

--- a/src/control/simple_delay_filter.rs
+++ b/src/control/simple_delay_filter.rs
@@ -151,8 +151,8 @@ mod tests {
 
     fn check_delay_history(
         simple_delay_filter: &SimpleDelayFilter,
-        value_1: &Vec<f64>,
-        value_2: &Vec<f64>,
+        value_1: &[f64],
+        value_2: &[f64],
     ) {
         check_delay_history_size(simple_delay_filter);
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -125,7 +125,7 @@ impl Controller {
     ///
     /// # Returns
     /// Some if the hardpoints are set. Otherwise, None.
-    pub fn set_hardpoints(&mut self, hardpoints: &Vec<usize>) -> Option<()> {
+    pub fn set_hardpoints(&mut self, hardpoints: &[usize]) -> Option<()> {
         // The first 3 should be the axial actuators. The last 3 should be the
         // tangent links.
         for (idx, hardpoint) in hardpoints.iter().enumerate().take(NUM_HARDPOINTS) {
@@ -155,7 +155,7 @@ impl Controller {
 
         // Update the configuration.
         let mut config = self.error_handler.config_control_loop.clone();
-        config.hardpoints = hardpoints.clone();
+        config.hardpoints = hardpoints.to_vec();
 
         info!("Set the hardpoints to {:?}.", hardpoints);
 

--- a/src/daq/data_acquisition.rs
+++ b/src/daq/data_acquisition.rs
@@ -41,6 +41,10 @@ pub struct DataAcquisition {
     pub event_queue: EventQueue,
     // Data acquisition mode
     pub mode: DataAcquisitionMode,
+    // Sequence ID of the last move actuator steps command. This is used to let
+    // the ControlLoopProcess can synchronize the commands and telemetry (as
+    // the results of commands).
+    _seq_id_move_actuator_steps: i32,
     // Plant model
     pub plant: Option<MockPlant>,
 }
@@ -77,6 +81,8 @@ impl DataAcquisition {
             event_queue: EventQueue::new(),
 
             mode: DataAcquisitionMode::Idle,
+
+            _seq_id_move_actuator_steps: 0,
 
             plant,
         }
@@ -224,6 +230,9 @@ impl DataAcquisition {
     /// Telemetry data.
     pub fn get_telemetry_ilc(&mut self) -> TelemetryControlLoop {
         let mut telemetry = TelemetryControlLoop::new();
+
+        // Put the sequence ID
+        telemetry.seq_id_move_actuator_steps = self._seq_id_move_actuator_steps;
 
         // Raw ILC data
         let (ilc_status, ilc_encoders, forces) = self.get_ilc_data_actuator();
@@ -421,11 +430,13 @@ impl DataAcquisition {
     /// Move the actuator steps.
     ///
     /// # Arguments
+    /// * `seq_id` - The sequence ID of the last command to move actuator steps
+    ///   (see CommandMoveActuatorSteps).
     /// * `actuator_steps` - The actuator steps to move.
     ///
     /// # Returns
     /// Some if the actuator steps are moved successfully. Otherwise, None.
-    pub fn move_actuator_steps(&mut self, actuator_steps: &[i32]) -> Option<()> {
+    pub fn move_actuator_steps(&mut self, seq_id: i32, actuator_steps: &[i32]) -> Option<()> {
         // Check the input
         if actuator_steps.len() != NUM_ACTUATOR {
             error!(
@@ -445,6 +456,7 @@ impl DataAcquisition {
         }
 
         // Do the actuator movement.
+        self._seq_id_move_actuator_steps = seq_id;
         if let Some(plant) = &mut self.plant {
             plant.move_actuator_steps(actuator_steps);
 
@@ -656,12 +668,15 @@ mod tests {
     #[test]
     fn test_get_telemetry_ilc() {
         let mut data_acquisition = create_data_acquisition(true);
+        data_acquisition._seq_id_move_actuator_steps = 1;
         if let Some(plant) = &mut data_acquisition.plant {
             plant.power_system_communication.is_power_on = true;
         }
 
         data_acquisition.get_telemetry_ilc();
         let telemetry = data_acquisition.get_telemetry_ilc();
+
+        assert_eq!(telemetry.seq_id_move_actuator_steps, 1);
 
         assert_relative_eq!(
             telemetry.forces["measured"][0],
@@ -733,21 +748,21 @@ mod tests {
         let actuator_steps_invalid = vec![100];
 
         assert!(data_acquisition
-            .move_actuator_steps(&actuator_steps_invalid)
+            .move_actuator_steps(1, &actuator_steps_invalid)
             .is_none());
 
         // Test with invalid mode
         let actuator_steps_valid = vec![100; NUM_ACTUATOR];
 
         assert!(data_acquisition
-            .move_actuator_steps(&actuator_steps_valid)
+            .move_actuator_steps(1, &actuator_steps_valid)
             .is_none());
 
         // Test with valid actuator steps and mode
         data_acquisition.set_mode(DataAcquisitionMode::Telemetry);
 
         assert!(data_acquisition
-            .move_actuator_steps(&actuator_steps_valid)
+            .move_actuator_steps(1, &actuator_steps_valid)
             .is_some());
     }
 

--- a/src/daq/data_acquisition_process.rs
+++ b/src/daq/data_acquisition_process.rs
@@ -48,7 +48,7 @@ use crate::utility::get_message_sequence_id;
 
 pub struct DataAcquisitionProcess {
     // Data acquisition (DAQ) system
-    _daq: DataAcquisition,
+    pub daq: DataAcquisition,
     // Command schema
     _command_schema: CommandSchema,
     // Sender of the telemetry to the control loop (inner-loop controller, ILC)
@@ -98,7 +98,7 @@ impl DataAcquisitionProcess {
         Self::check_divisor(config.frequency_loop, config.frequency_toggle_bit);
 
         Self {
-            _daq: daq,
+            daq,
 
             _command_schema: Self::create_command_schema(),
 
@@ -170,10 +170,10 @@ impl DataAcquisitionProcess {
     pub fn run(&mut self) {
         info!("Data acquisition loop is running.");
 
-        self._daq.init_default_digital_output();
+        self.daq.init_default_digital_output();
 
         // Max counter to send the telemetry.
-        let config = &self._daq.config;
+        let config = &self.daq.config;
         let max_counter_send_telemetry =
             (config.frequency_loop / config.frequency_send_telemetry) as u64;
 
@@ -194,7 +194,7 @@ impl DataAcquisitionProcess {
             if let Ok(message) = self._receiver_to_daq.try_recv() {
                 command_result = Some(self._command_schema.execute(
                     &message,
-                    Some(&mut self._daq),
+                    Some(&mut self.daq),
                     None,
                     None,
                     None,
@@ -209,11 +209,11 @@ impl DataAcquisitionProcess {
 
             // Send the command result or events to the model. Ignore the
             // error.
-            let has_events = self._daq.event_queue.has_event();
+            let has_events = self.daq.event_queue.has_event();
             if command_result.is_some() || has_events {
                 // Get the events.
                 let events = if has_events {
-                    Some(self._daq.event_queue.get_events_and_clear())
+                    Some(self.daq.event_queue.get_events_and_clear())
                 } else {
                     None
                 };
@@ -231,21 +231,21 @@ impl DataAcquisitionProcess {
                 // Always send the power telemetry data.
                 let _ = self
                     ._sender_telemetry_to_power
-                    .try_send(self._daq.get_telemetry_power());
+                    .try_send(self.daq.get_telemetry_power());
 
                 // When the system is not in idle mode, there is the ILC
                 // telemetry data to send.
-                if self._daq.mode != DataAcquisitionMode::Idle {
+                if self.daq.mode != DataAcquisitionMode::Idle {
                     let _ = self
                         ._sender_telemetry_to_control_loop
-                        .try_send(self._daq.get_telemetry_ilc());
+                        .try_send(self.daq.get_telemetry_ilc());
                 }
             }
 
             // Toggle the bit of the closed-loop control for the safety module
             // to use.
             if (counter % max_counter_toggle_bit) == 0 {
-                self._daq.toggle_bit_closed_loop_control();
+                self.daq.toggle_bit_closed_loop_control();
             }
 
             // Update the counter.
@@ -340,18 +340,14 @@ mod tests {
             data_acquisition.run();
         });
 
-        sleep(Duration::from_millis(500));
-
         // Check to get the power telemetry data.
-        let mut received_telemetry_power = TelemetryPower::new();
+        let received_telemetry_power;
         loop {
-            match receiver_telemetry_to_power.try_recv() {
-                Ok(telemetry_power) => {
-                    received_telemetry_power = telemetry_power;
-                }
-                Err(_) => {
-                    break;
-                }
+            if let Ok(telemetry_power) =
+                receiver_telemetry_to_power.recv_timeout(Duration::from_millis(50))
+            {
+                received_telemetry_power = telemetry_power;
+                break;
             }
         }
 
@@ -383,18 +379,11 @@ mod tests {
         }));
 
         // Check the telemetry data.
-        sleep(Duration::from_millis(500));
-
-        let mut latest_telemetry = Telemetry::new(None, None, None, None);
+        let latest_telemetry;
         loop {
-            match receiver_to_model.try_recv() {
-                Ok(telemetry) => {
-                    if let Some(_result) = &telemetry.command_result {
-                        latest_telemetry = telemetry;
-                        break;
-                    }
-                }
-                Err(_) => {
+            if let Ok(telemetry) = receiver_to_model.recv_timeout(Duration::from_millis(50)) {
+                if let Some(_) = &telemetry.command_result {
+                    latest_telemetry = telemetry;
                     break;
                 }
             }
@@ -410,13 +399,11 @@ mod tests {
 
         // There should be ILC telemetry data when not in idle mode.
         loop {
-            match receiver_telemetry_to_control_loop.try_recv() {
-                Ok(_) => {
-                    has_telemetry_control_loop = true;
-                }
-                Err(_) => {
-                    break;
-                }
+            if let Ok(_) =
+                receiver_telemetry_to_control_loop.recv_timeout(Duration::from_millis(50))
+            {
+                has_telemetry_control_loop = true;
+                break;
             }
         }
 

--- a/src/interface/command_server.rs
+++ b/src/interface/command_server.rs
@@ -22,7 +22,6 @@
 use log::info;
 use serde_json::Value;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
-use std::thread::sleep;
 use std::time::Duration;
 
 use crate::constants::BOUND_SYNC_CHANNEL;
@@ -132,8 +131,6 @@ impl CommandServer {
     /// * `tcp_server` - TCP server.
     /// * `command_server` - Command server.
     pub fn process_command(tcp_server: &mut TcpServer, command_server: &mut CommandServer) {
-        let mut is_processed = false;
-
         // Check the command/event from the TCP/IP and send to the internal use.
         let message_received = tcp_server.read_json();
         if !message_received.is_null() {
@@ -174,21 +171,14 @@ impl CommandServer {
             } else {
                 info!("Invalid command/event message: {message_received}.");
             }
-
-            is_processed = true;
         }
 
         // Check the internal command result or event, and send to the TCP/IP.
-        if let Ok(message_send) = command_server.receiver_to_tcp.try_recv() {
+        if let Ok(message_send) = command_server
+            .receiver_to_tcp
+            .recv_timeout(Duration::from_millis(tcp_server.timeout))
+        {
             tcp_server.write_jsons(&message_send);
-
-            is_processed = true;
-        }
-
-        // Sleep for a while to avoid busy waiting if no telemetry is received or
-        // sent.
-        if !is_processed {
-            sleep(Duration::from_millis(tcp_server.timeout));
         }
     }
 
@@ -215,12 +205,12 @@ mod tests {
         atomic::{AtomicBool, Ordering},
         Arc,
     };
-    use std::thread::spawn;
+    use std::thread::{sleep, spawn};
 
     use crate::constants::{LOCAL_HOST, TERMINATOR};
     use crate::utility::{client_read_and_assert, client_write_and_sleep};
 
-    const SLEEP_TIME: u64 = 100;
+    const SLEEP_TIME: u64 = 50;
     const MAX_TIMEOUT: u64 = 200;
 
     fn create_command_server() -> (CommandServer, SyncSender<Value>, Receiver<Value>) {

--- a/src/interface/tcp_server.rs
+++ b/src/interface/tcp_server.rs
@@ -240,8 +240,8 @@ impl TcpServer {
     /// existing data instead.
     ///
     /// # Arguments
-    /// * `items` - A vector of Value instances that holds the JSON data.
-    pub fn write_jsons(&mut self, items: &Vec<Value>) {
+    /// * `items` - A slice of Value instances that holds the JSON data.
+    pub fn write_jsons(&mut self, items: &[Value]) {
         if let Some(stream) = self._writer.as_mut() {
             if !stream.buffer().is_empty() {
                 self.flush();

--- a/src/interface/telemetry_server.rs
+++ b/src/interface/telemetry_server.rs
@@ -22,7 +22,6 @@
 use log::info;
 use serde_json::Value;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
-use std::thread::sleep;
 use std::time::Duration;
 
 use crate::constants::BOUND_SYNC_CHANNEL;
@@ -71,8 +70,6 @@ impl TelemetryServer {
     /// * `tcp_server` - TCP server.
     /// * `telemetry_server` - Telemetry server.
     pub fn process_telemetry(tcp_server: &mut TcpServer, telemetry_server: &mut TelemetryServer) {
-        let mut is_processed = false;
-
         // Check the telemetry from the TCP/IP and send to the internal use.
         let telemetry_received = tcp_server.read_json();
         if !telemetry_received.is_null() {
@@ -82,24 +79,17 @@ impl TelemetryServer {
                 let _ = telemetry_server
                     .sender_from_tcp
                     .try_send(telemetry_received);
-
-                is_processed = true;
             } else {
                 info!("Invalid telemetry message: {telemetry_received}.");
             }
         }
 
         // Check the internal telemetry and send to the TCP/IP.
-        if let Ok(telemetry_send) = telemetry_server.receiver_to_tcp.try_recv() {
+        if let Ok(telemetry_send) = telemetry_server
+            .receiver_to_tcp
+            .recv_timeout(Duration::from_millis(tcp_server.timeout))
+        {
             tcp_server.write_jsons(&telemetry_send);
-
-            is_processed = true;
-        }
-
-        // Sleep for a while to avoid busy waiting if no telemetry is received or
-        // sent.
-        if !is_processed {
-            sleep(Duration::from_millis(tcp_server.timeout));
         }
     }
 }
@@ -114,12 +104,12 @@ mod tests {
         atomic::{AtomicBool, Ordering},
         Arc,
     };
-    use std::thread::spawn;
+    use std::thread::{sleep, spawn};
 
     use crate::constants::{LOCAL_HOST, TERMINATOR};
     use crate::utility::{client_read_and_assert, client_write_and_sleep};
 
-    const SLEEP_TIME: u64 = 100;
+    const SLEEP_TIME: u64 = 50;
     const MAX_TIMEOUT: u64 = 200;
 
     fn create_telemetry_server() -> (TelemetryServer, SyncSender<Value>, Receiver<Value>) {

--- a/src/mock/mock_plant.rs
+++ b/src/mock/mock_plant.rs
@@ -40,13 +40,11 @@ use crate::mock::mock_constants::{
 use crate::mock::mock_inner_loop_controller::MockInnerLoopController;
 use crate::mock::mock_power_system::MockPowerSystem;
 use crate::power::config_power::ConfigPower;
-use crate::utility::{get_parameter, read_file_disp_ims};
+use crate::utility::get_parameter;
 
 #[derive(Clone)]
 pub struct MockPlant {
     _static_transfer_matrix: SMatrix<f64, NUM_ACTUATOR, NUM_ACTUATOR>,
-    _disp_matrix_inv: SMatrix<f64, NUM_IMS_READING, NUM_SPACE_DEGREE_OF_FREEDOM>,
-    _disp_offset: SVector<f64, NUM_IMS_READING>,
     // Current positions of the actuator in steps referenced to the home
     // position.
     pub actuator_steps: Vec<i32>,
@@ -92,10 +90,6 @@ impl MockPlant {
                 .flat_map(|row| row.iter().copied()),
         );
 
-        let (disp_matrix, disp_offset) = read_file_disp_ims(Path::new("config/disp_ims.yaml"));
-        let disp_smatrix: SMatrix<f64, NUM_SPACE_DEGREE_OF_FREEDOM, NUM_IMS_READING> =
-            SMatrix::from_row_iterator(disp_matrix.iter().flat_map(|row| row.iter().copied()));
-
         let filepath = Path::new("config/parameters_control.yaml");
         let inclinometer_offset = get_parameter(filepath, "inclinometer_offset");
         let mirror_weight_kg = get_parameter(filepath, "mirror_weight_kg");
@@ -133,11 +127,6 @@ impl MockPlant {
 
         Self {
             _static_transfer_matrix: matrix,
-
-            _disp_matrix_inv: disp_smatrix
-                .pseudo_inverse(f64::EPSILON)
-                .expect("Should be able to compute the pseudo inverse of displacement matrix."),
-            _disp_offset: SVector::from_iterator(disp_offset.iter().copied()),
 
             actuator_steps: vec![0; NUM_ACTUATOR],
             _actuator_force_weight: Self::get_forces_mirror_weight(
@@ -462,6 +451,8 @@ impl MockPlant {
     /// rigid body position.
     ///
     /// # Arguments
+    /// * `disp_matrix_inv` - The pseudo-inverse of the displacement matrix.
+    /// * `disp_offset` - The displacement offset.
     /// * `x` - The x position in micron.
     /// * `y` - The y position in micron.
     /// * `z` - The z position in micron.
@@ -471,8 +462,10 @@ impl MockPlant {
     ///
     /// # Returns
     /// A tuple of the theta_z and delta_z readings in micron.
+    #[allow(clippy::too_many_arguments)]
     pub fn calculate_ims_readings(
-        &self,
+        disp_matrix_inv: &SMatrix<f64, NUM_IMS_READING, NUM_SPACE_DEGREE_OF_FREEDOM>,
+        disp_offset: &SVector<f64, NUM_IMS_READING>,
         x: f64,
         y: f64,
         z: f64,
@@ -481,9 +474,8 @@ impl MockPlant {
         rz: f64,
     ) -> (Vec<f64>, Vec<f64>) {
         // Change the unit from mm to um
-        let reading_ims = (self._disp_matrix_inv * SVector::from_vec(vec![x, y, z, rx, ry, rz])
-            + self._disp_offset)
-            * 1e3;
+        let reading_ims =
+            (disp_matrix_inv * SVector::from_vec(vec![x, y, z, rx, ry, rz]) + disp_offset) * 1e3;
 
         let theta_z = [8, 10, 4, 6, 0, 2]
             .iter()
@@ -508,7 +500,7 @@ mod tests {
         TEST_DIGITAL_INPUT_NO_POWER, TEST_DIGITAL_INPUT_POWER_COMM,
         TEST_DIGITAL_INPUT_POWER_COMM_MOTOR,
     };
-    use crate::utility::read_file_stiffness;
+    use crate::utility::{read_file_disp_ims, read_file_stiffness};
 
     const EPSILON: f64 = 1e-7;
 
@@ -892,18 +884,30 @@ mod tests {
 
     #[test]
     fn test_calculate_ims_readings() {
-        let mock_plant = create_mock_plant();
+        let (matrix, offset) = read_file_disp_ims(Path::new("config/disp_ims.yaml"));
+        let disp_matrix: SMatrix<f64, NUM_SPACE_DEGREE_OF_FREEDOM, NUM_IMS_READING> =
+            SMatrix::from_row_iterator(matrix.iter().flat_map(|row| row.iter().copied()));
+        let disp_offset: SVector<f64, NUM_IMS_READING> =
+            SVector::from_iterator(offset.iter().copied());
 
-        let (disp_matrix, disp_offset) = read_file_disp_ims(Path::new("config/disp_ims.yaml"));
-        let matrix: SMatrix<f64, NUM_SPACE_DEGREE_OF_FREEDOM, NUM_IMS_READING> =
-            SMatrix::from_row_iterator(disp_matrix.iter().flat_map(|row| row.iter().copied()));
-        let offset: SVector<f64, NUM_IMS_READING> =
-            SVector::from_iterator(disp_offset.iter().copied());
+        let disp_matrix_inv = disp_matrix
+            .pseudo_inverse(f64::EPSILON)
+            .expect("Should be able to compute the pseudo inverse of displacement matrix.");
 
         // Zero position
-        let (theta_z, delta_z) = mock_plant.calculate_ims_readings(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        let (theta_z, delta_z) = MockPlant::calculate_ims_readings(
+            &disp_matrix_inv,
+            &disp_offset,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        );
 
-        let (x, y, z, rx, ry, rz) = calculate_position_ims(&matrix, &offset, &theta_z, &delta_z);
+        let (x, y, z, rx, ry, rz) =
+            calculate_position_ims(&disp_matrix, &disp_offset, &theta_z, &delta_z);
 
         assert_relative_eq!(x, 0.0, epsilon = EPSILON);
         assert_relative_eq!(y, 0.0, epsilon = EPSILON);
@@ -913,10 +917,19 @@ mod tests {
         assert_relative_eq!(rz, 0.0, epsilon = EPSILON);
 
         // Non-zero position
-        let (theta_z, delta_z) =
-            mock_plant.calculate_ims_readings(10.0, 20.0, 30.0, 40.0, 50.0, 60.0);
+        let (theta_z, delta_z) = MockPlant::calculate_ims_readings(
+            &disp_matrix_inv,
+            &disp_offset,
+            10.0,
+            20.0,
+            30.0,
+            40.0,
+            50.0,
+            60.0,
+        );
 
-        let (x, y, z, rx, ry, rz) = calculate_position_ims(&matrix, &offset, &theta_z, &delta_z);
+        let (x, y, z, rx, ry, rz) =
+            calculate_position_ims(&disp_matrix, &disp_offset, &theta_z, &delta_z);
 
         assert_relative_eq!(x, 10.0, epsilon = EPSILON);
         assert_relative_eq!(y, 20.0, epsilon = EPSILON);

--- a/src/model.rs
+++ b/src/model.rs
@@ -19,7 +19,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use log::{debug, info};
+use log::{debug, error, info};
 use serde_json::Value;
 use std::{
     collections::HashMap,
@@ -34,9 +34,8 @@ use std::{
 
 use crate::command::{
     command_control_loop::{
-        CommandApplyForces, CommandGetInnerLoopControlMode, CommandMoveActuators,
-        CommandPositionMirror, CommandResetActuatorSteps, CommandResetForceOffsets,
-        CommandSetClosedLoopControlMode, CommandSetInnerLoopControlMode,
+        CommandApplyForces, CommandMoveActuators, CommandPositionMirror, CommandResetActuatorSteps,
+        CommandResetForceOffsets, CommandSetClosedLoopControlMode,
     },
     command_controller::{
         CommandClearErrors, CommandEnableOpenLoopMaxLimit, CommandLoadConfiguration,
@@ -45,7 +44,9 @@ use crate::command::{
         CommandSetMirrorHome, CommandSetTemperatureOffset, CommandSwitchCommandSource,
         CommandSwitchForceBalanceSystem,
     },
-    command_data_acquisition::CommandSwitchDigitalOutput,
+    command_data_acquisition::{
+        CommandGetInnerLoopControlMode, CommandSetInnerLoopControlMode, CommandSwitchDigitalOutput,
+    },
     command_power_system::{CommandPower, CommandResetBreakers},
     command_schema::{Command, CommandSchema},
 };
@@ -187,7 +188,11 @@ impl Model {
     fn create_commands() -> HashMap<String, Vec<String>> {
         // The commands here need to be in the
         // DataAcquisitionProcess.create_command_schema()
-        let commands_data_acquisition = vec![CommandSwitchDigitalOutput.name().to_string()];
+        let commands_data_acquisition = vec![
+            CommandSwitchDigitalOutput.name().to_string(),
+            CommandGetInnerLoopControlMode.name().to_string(),
+            CommandSetInnerLoopControlMode.name().to_string(),
+        ];
 
         // The commands here need to be in the
         // PowerSystemProcess.create_command_schema()
@@ -205,8 +210,6 @@ impl Model {
             CommandPositionMirror.name().to_string(),
             CommandResetActuatorSteps.name().to_string(),
             CommandMoveActuators.name().to_string(),
-            CommandGetInnerLoopControlMode.name().to_string(),
-            CommandSetInnerLoopControlMode.name().to_string(),
         ];
 
         let controller_command_schema = Self::create_controller_command_schema();
@@ -545,6 +548,7 @@ impl Model {
     /// new telemetry.
     pub fn step(&mut self) {
         // Check the message from the GUI
+        let commander_before_gui_command = self._controller.commander;
         let mut gui_has_valid_command = false;
         if let Some(receiver) = &self._receivers_from_tcp[&Commander::GUI] {
             if let Ok(message) = receiver.try_recv() {
@@ -562,9 +566,16 @@ impl Model {
             }
         }
 
-        // Change the commander if the GUI has a valid command
-        if gui_has_valid_command && (self._controller.commander != Commander::GUI) {
-            self._controller.commander = Commander::GUI;
+        let change_commander_from_gui_to_csc = (commander_before_gui_command == Commander::GUI)
+            && (self._controller.commander == Commander::CSC);
+
+        // Change the commander if the GUI has a valid command. But do not do
+        // this if this is to switch the commander back to CSC.
+        if gui_has_valid_command
+            && (!change_commander_from_gui_to_csc)
+            && (self._controller.commander != Commander::GUI)
+        {
+            self._controller.set_commander(Commander::GUI);
         }
 
         // Check the message from the CSC
@@ -714,6 +725,9 @@ impl Model {
         if is_command(&name) {
             // Fail the command if the source is CSC but the commander is GUI
             if (controller.commander == Commander::GUI) && (source == Commander::CSC) {
+                error!(
+                    "The command {name} from CSC is rejected because the current commander is GUI."
+                );
                 let _ = sender_to_tcp.try_send(vec![acknowledge_command(
                     CommandStatus::Fail,
                     get_message_sequence_id(message),
@@ -1094,6 +1108,7 @@ mod tests {
     use std::thread::sleep;
     use std::time::Duration;
 
+    use crate::command::command_data_acquisition::CommandSetDataAcquisitionMode;
     use crate::constants::{LOCAL_HOST, NUM_INNER_LOOP_CONTROLLER, TERMINATOR};
     use crate::enums::{DataAcquisitionMode, InnerLoopControlMode, PowerSystemState};
     use crate::mock::mock_constants::{
@@ -1372,6 +1387,11 @@ mod tests {
         );
 
         wait_for_command_result_and_reset(&mut model);
+
+        client_read_and_assert(
+            &mut client_command_gui,
+            "{\"id\":\"commandableByDDS\",\"state\":false}\r\n",
+        );
 
         client_read_and_assert(
             &mut client_command_gui,
@@ -1738,12 +1758,30 @@ mod tests {
         model.run_processes();
 
         // Create the clients to connect the servers
-        let (_client_command_csc, mut client_telemetry_csc) =
+        let (mut client_command_csc, mut client_telemetry_csc) =
             create_tcp_clients(model._ports["csc_command"], model._ports["csc_telemetry"]);
 
         sleep(Duration::from_millis(MAX_TIMEOUT));
 
         wait_for_connection(&mut model);
+
+        // Power on the communication system and set the data acquisition mode
+        // to telemetry
+        client_write_and_sleep(
+            &mut client_command_csc,
+            "{\"id\":\"cmd_power\",\"sequence_id\":1,\"status\":true,\"powerType\":2}\r\n",
+            SLEEP_TIME,
+        );
+        wait_for_command_result_and_reset(&mut model);
+
+        if let Some(sender) = model._controller.sender_to_daq.as_ref() {
+            let _ = sender.try_send(json!(
+                {
+                    "id": CommandSetDataAcquisitionMode.name(),
+                    "mode": DataAcquisitionMode::Telemetry as u8,
+                }
+            ));
+        }
 
         // Write the telemetry of the external elevation angle.
         client_write_and_sleep(
@@ -1755,20 +1793,14 @@ mod tests {
         let max_num = 100;
         let mut idx = 0;
         for _ in 0..max_num {
-            idx += 1;
             model.step();
-
-            let elevation = model
-                ._controller
-                .last_effective_telemetry
-                .control_loop
-                .clone()
-                .unwrap()
-                .inclinometer["external"];
-
-            if elevation == 12.34 {
-                break;
+            if let Some(telemetry) = &model._controller.last_effective_telemetry.control_loop {
+                if telemetry.inclinometer["external"] == 12.34 {
+                    break;
+                }
             }
+
+            idx += 1;
         }
 
         assert!(idx < max_num);
@@ -1814,10 +1846,20 @@ mod tests {
             "{\"id\":\"success\",\"sequence_id\":1}\r\n",
         );
 
-        // Command should change to the GUI.
+        client_read_and_assert(
+            &mut client_command_gui,
+            "{\"id\":\"commandableByDDS\",\"state\":false}\r\n",
+        );
+
+        // Commander should change to the GUI.
         assert_eq!(model._controller.commander, Commander::GUI);
 
         // Command from the CSC should fail.
+        client_read_and_assert(
+            &mut client_command_csc,
+            "{\"id\":\"commandableByDDS\",\"state\":false}\r\n",
+        );
+
         client_write_and_sleep(
             &mut client_command_csc,
             "{\"id\":\"cmd_clearErrors\",\"sequence_id\":2}\r\n",
@@ -1834,6 +1876,39 @@ mod tests {
         client_read_and_assert(
             &mut client_command_csc,
             "{\"id\":\"fail\",\"sequence_id\":2}\r\n",
+        );
+
+        // Change the commander to the CSC again.
+        client_write_and_sleep(
+            &mut client_command_gui,
+            "{\"id\":\"cmd_switchCommandSource\",\"isRemote\":true,\"sequence_id\":2}\r\n",
+            SLEEP_TIME,
+        );
+
+        client_read_and_assert(
+            &mut client_command_gui,
+            "{\"id\":\"ack\",\"sequence_id\":2}\r\n",
+        );
+
+        wait_for_command_result_and_reset(&mut model);
+
+        client_read_and_assert(
+            &mut client_command_gui,
+            "{\"id\":\"success\",\"sequence_id\":2}\r\n",
+        );
+
+        client_read_and_assert(
+            &mut client_command_gui,
+            "{\"id\":\"commandableByDDS\",\"state\":true}\r\n",
+        );
+
+        // Commander should change to the CSC.
+        assert_eq!(model._controller.commander, Commander::CSC);
+
+        // Check the CSC gets this new event
+        client_read_and_assert(
+            &mut client_command_csc,
+            "{\"id\":\"commandableByDDS\",\"state\":true}\r\n",
         );
 
         model.stop();

--- a/src/model.rs
+++ b/src/model.rs
@@ -956,7 +956,7 @@ impl Model {
     ///
     /// # Arguments
     /// * `events` - Events.
-    fn process_subsystem_event(&mut self, events: &Vec<Value>) {
+    fn process_subsystem_event(&mut self, events: &[Value]) {
         for event in events {
             let name = get_message_name(event);
             if name == "powerSystemState" {
@@ -1148,7 +1148,7 @@ mod tests {
         messages
     }
 
-    fn get_specific_message(messages: &Vec<Value>, name: &str) -> Option<Value> {
+    fn get_specific_message(messages: &[Value], name: &str) -> Option<Value> {
         for message in messages {
             if get_message_name(message) == name {
                 return Some(message.clone());

--- a/src/power/power_system_process.rs
+++ b/src/power/power_system_process.rs
@@ -393,16 +393,10 @@ mod tests {
     fn wait_events(receiver_to_model: &Receiver<Telemetry>) -> Telemetry {
         let latest_telemetry;
         loop {
-            match receiver_to_model.try_recv() {
-                Ok(telemetry) => {
-                    if telemetry.events.is_some() {
-                        latest_telemetry = telemetry;
-                        break;
-                    }
-                }
-
-                Err(_) => {
-                    sleep(Duration::from_millis(100));
+            if let Ok(telemetry) = receiver_to_model.recv_timeout(Duration::from_millis(50)) {
+                if telemetry.events.is_some() {
+                    latest_telemetry = telemetry;
+                    break;
                 }
             }
         }

--- a/src/telemetry/event.rs
+++ b/src/telemetry/event.rs
@@ -127,7 +127,7 @@ impl Event {
     ///
     /// # Returns
     /// The message of the bypassed actuator ILCs.
-    pub fn get_message_bypassed_actuator_ilcs(ilcs: &Vec<usize>) -> Value {
+    pub fn get_message_bypassed_actuator_ilcs(ilcs: &[usize]) -> Value {
         json!({
             "id": "bypassedActuatorILCs",
             "ilcs": ilcs,
@@ -175,7 +175,7 @@ impl Event {
     ///
     /// # Returns
     /// The message of the temperature offset in degree C.
-    pub fn get_message_temperature_offset(ring: &Vec<f64>) -> Value {
+    pub fn get_message_temperature_offset(ring: &[f64]) -> Value {
         json!({
             "id": "temperatureOffset",
             "ring": ring,

--- a/src/telemetry/telemetry_control_loop.rs
+++ b/src/telemetry/telemetry_control_loop.rs
@@ -64,6 +64,9 @@ pub struct TelemetryControlLoop {
     pub force_balance: HashMap<String, f64>,
     // Cycle time in second.
     pub cycle_time: f64,
+    // Sequence ID of the last command to move actuator steps
+    // (see CommandMoveActuatorSteps).
+    pub seq_id_move_actuator_steps: i32,
 }
 
 impl TelemetryDefault for TelemetryControlLoop {
@@ -135,6 +138,8 @@ impl TelemetryControlLoop {
             force_balance: Self::initialize_dict_value(&["fx", "fy", "fz", "mx", "my", "mz"], 0.0),
 
             cycle_time: 0.0,
+
+            seq_id_move_actuator_steps: 0,
         }
     }
 


### PR DESCRIPTION
- Put the **timeout** value to be 50 ms in `parameters_app.yaml`.
- Improve the clippy format.
- Put the `MockPlant.calculate_ims_readings()` to be static.
- Add the `disp_matrix_inv` field in **Config**.
- Remove the `_is_simulation_mode` field in **OpenLoop**.
- Remove the simulation of **MockPlant** from the **ControlLoop**.
The related simulation goes to the **DataAcquisition** instead.
- Add the command of data acquisition to the **Model**.
- Use the `Receiver.recv_timeout()` instead of `Receiver.try_recv()` in **CommandServer**,  **TelemetryServer**, and **DataAcquisitionProcess** (in the test).
- Use the `Receiver.recv_timeout()` in the tests of **PowerSystemProcess**.
- Add the `seq_id_move_actuator_steps` field in **CommandMoveActuatorSteps** and **TelemetryControlLoop**.
The **DataAcquisition** will cache this value.
- Fix the switch of commander in `model.rs`.