### PR TITLE
Tickets/osw 2381

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ The UML diagrams are used to detail the system design for each subsystem in the 
 The GitHub supports the [Mermaid](https://github.com/mermaid-js/mermaid) natively.
 You can use the [online editor](https://mermaid.live) to edit them.
 
+## Tricky Parts of the Code Tuning with the Inner-Loop Controller (ILC)
+
+For the actuator ILC, if you do not issue the broadcast `step()` command first, the received status/force frame data is just some garbage data.
+The status and force will be 0 and the encoder value is some random huge value (out of available encoder range).
+For the monitor ILC, you might get the `inf` value when just starting up the ILCs.
+We always have this for the temperature ILCs.
+Sometime, the displacement ILC gives the `inf` value as well.
+
 ## Version History
 
 See [here](doc/version_history.md) for the version history.

--- a/config/parameters_power.yaml
+++ b/config/parameters_power.yaml
@@ -49,8 +49,8 @@ output_voltage_settling_time_communication: 10
 output_voltage_settling_time_motor: 20
 
 # Output voltage fall time in millisecond for the communication and motor.
-output_voltage_fall_time_communication: 50
-output_voltage_fall_time_motor: 300
+output_voltage_fall_time_communication: 200
+output_voltage_fall_time_motor: 400
 
 # The physical amounts of time in millisecond that they take for the power
 # relay to open and closed its contacts. These values are common to both motor 

--- a/doc/version_history.md
+++ b/doc/version_history.md
@@ -1,5 +1,22 @@
 # Version History
 
+0.5.2
+
+- Update the `ErrorHandler.check_condition_control_loop()` to only check the actuator ILC after broadcasting the `step()` command to actuator ILCs.
+- Add the debug messages in **ErrorHandler**.
+- Update the `ErrorHandler.check_cycle_time()` to pass the cycle_time as milliseconds.
+- Update the `DataAcquisition.check_ilc_stale_data()` that only check the communication counter after broadcasting the `step()` command to ILCs.
+- Reset the `DataAcquisition._seq_id_move_actuator_steps` when transitioning to the **Idle** mode.
+- Add the `ControlLoop.get_control_mode()`.
+- Use the cached ILC monitor data if the received values are inf in **DataAcquisition**.
+- Reset the `seq_id_move_actuator_steps` in `ControlLoopProcess.run()`.
+- Improve the error message in **SubPowerSystem**.
+- Update the **output_voltage_fall_time_communication** and **output_voltage_fall_time_motor** in `parameters_power.yaml`.
+- Change the unit of `TelemetryControlLoop.cycle_time` to be milliseconds.
+- Add the debug message for the loop time in **DataAcquisitionProcess** and record the `cycle_time`.
+- Compare and record the cycle times of **ControlLoopProcess** and **DataAcquisitionProcess**.
+- Simulate the ILC latency in **DataAcquisition**.
+
 0.5.1
 
 - Use the `flexi_logger` to replace the `simplelog` dependency.

--- a/src/control/control_loop.rs
+++ b/src/control/control_loop.rs
@@ -19,7 +19,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use log::info;
+use log::{debug, info};
 use nalgebra::SMatrix;
 use std::path::Path;
 
@@ -121,12 +121,31 @@ impl ControlLoop {
         self._mode = mode;
         info!("Control mode is set to: {:?}.", mode);
 
+        if self._mode == ClosedLoopControlMode::Idle {
+            self.reset_steps();
+            self.reset_force();
+
+            self._steps_to_move_actuators = None;
+
+            debug!(
+                "The control loop is in idle mode. The active movement steps and forces are reset to 0."
+            );
+        }
+
         self.event_queue
             .add_event(Event::get_message_closed_loop_control_mode(mode));
         self.event_queue
             .add_event(Event::get_message_force_balance_system_status(
                 mode == ClosedLoopControlMode::ClosedLoop,
             ));
+    }
+
+    /// Get the control mode.
+    ///
+    /// # Returns
+    /// The control mode.
+    pub fn get_control_mode(&self) -> ClosedLoopControlMode {
+        self._mode
     }
 
     /// Create a closed-loop.
@@ -996,6 +1015,7 @@ mod tests {
     fn test_update_control_mode() {
         let mut control_loop = create_control_loop(true);
 
+        // Test to update to the closed-loop control mode.
         control_loop.update_control_mode(ClosedLoopControlMode::ClosedLoop);
 
         assert_eq!(control_loop._mode, ClosedLoopControlMode::ClosedLoop);
@@ -1011,6 +1031,27 @@ mod tests {
                     "status": true,
                 })
             ]
+        );
+
+        // Test to update to the idle mode.
+        control_loop._steps_to_move_actuators = Some(vec![1; NUM_ACTUATOR]);
+
+        control_loop.update_control_mode(ClosedLoopControlMode::Idle);
+
+        assert_eq!(control_loop._mode, ClosedLoopControlMode::Idle);
+        assert_eq!(control_loop._steps_to_move_actuators, None);
+    }
+
+    #[test]
+    fn test_get_control_mode() {
+        let mut control_loop = create_control_loop(true);
+
+        assert_eq!(control_loop.get_control_mode(), ClosedLoopControlMode::Idle);
+
+        control_loop._mode = ClosedLoopControlMode::OpenLoop;
+        assert_eq!(
+            control_loop.get_control_mode(),
+            ClosedLoopControlMode::OpenLoop
         );
     }
 

--- a/src/control/control_loop_process.rs
+++ b/src/control/control_loop_process.rs
@@ -40,6 +40,7 @@ use crate::command::{
 use crate::config::Config;
 use crate::constants::BOUND_SYNC_CHANNEL;
 use crate::control::control_loop::ControlLoop;
+use crate::enums::ClosedLoopControlMode;
 use crate::telemetry::{telemetry::Telemetry, telemetry_control_loop::TelemetryControlLoop};
 use crate::utility::{get_message_name, get_message_sequence_id};
 
@@ -152,6 +153,9 @@ impl ControlLoopProcess {
         // Telemetry command name
         let telemetry_command_name = CommandSetExternalElevation.name();
 
+        // Command name for setting the closed-loop control mode.
+        let set_mode_command_name = CommandSetClosedLoopControlMode.name();
+
         let period = (1000.0 / self.control_loop.config.control_frequency) as u64;
         let mut seq_id_move_actuator_steps = 0;
         let mut processed_telemetry: Option<TelemetryControlLoop> = None;
@@ -175,6 +179,7 @@ impl ControlLoopProcess {
             let mut had_processed_telemetry_command = false;
             let mut is_telemetry_command = false;
             let mut is_internal_command = false;
+            let mut is_set_mode_command = false;
             while let Ok(message) = self._receiver_to_control_loop.try_recv() {
                 command_result = Some(self._command_schema.execute(
                     &message,
@@ -185,6 +190,7 @@ impl ControlLoopProcess {
                 ));
 
                 is_internal_command = get_message_sequence_id(&message) == -1;
+                is_set_mode_command = get_message_name(&message) == set_mode_command_name;
 
                 // If we receive a telemetry command as the first time,
                 // continue to process the second command.
@@ -197,7 +203,7 @@ impl ControlLoopProcess {
 
                 // Break the loop if we processed a non-telemetry
                 // command or two consecutive telemetry commands.
-                if !is_telemetry_command || had_processed_telemetry_command {
+                if (!is_telemetry_command) || had_processed_telemetry_command {
                     break;
                 }
             }
@@ -207,6 +213,20 @@ impl ControlLoopProcess {
                 command_result = None;
             }
 
+            // If the received command is to set the closed-loop control mode
+            // to be Idle, we need to reset the sequence of moving actuator
+            // steps.
+            if is_set_mode_command
+                && (self.control_loop.get_control_mode() == ClosedLoopControlMode::Idle)
+            {
+                seq_id_move_actuator_steps = 0;
+                info!(
+                    "The closed-loop control mode is set to idle. The sequence ID of moving actuators is reset to 0."
+                );
+            }
+
+            // After issuing the new step command, the sequence ID of moving
+            // actuator steps should be > 0.
             if let Some(steps) = self.control_loop.take_steps_to_move_actuators() {
                 seq_id_move_actuator_steps =
                     self.get_next_seq_id_move_actuator_steps(seq_id_move_actuator_steps);

--- a/src/control/control_loop_process.rs
+++ b/src/control/control_loop_process.rs
@@ -257,7 +257,11 @@ impl ControlLoopProcess {
             let cycle_time = now.elapsed().as_millis() as u64;
 
             if let Some(telemetry) = &mut processed_telemetry {
-                telemetry.cycle_time = (cycle_time as f64) / 1000.0;
+                // Record the longer cycle time (control loop process vs data
+                // acquisition process) in the telemetry.
+                if telemetry.cycle_time < cycle_time {
+                    telemetry.cycle_time = cycle_time;
+                }
             }
 
             let _ = self._sender_to_model.try_send(Telemetry::new(

--- a/src/daq/data_acquisition.rs
+++ b/src/daq/data_acquisition.rs
@@ -436,6 +436,12 @@ impl DataAcquisition {
         if let Some(frame_request) = self._ilc.get_frame_get_force_and_status(idx) {
             if let Some(plant) = &mut self.plant {
                 frame_payload = plant.request_ilc(frame_request);
+
+                // Sleep for a while to simulate the latency of the ILC in the
+                // real hardware mode.
+                sleep(Duration::from_micros(
+                    self.config.latency["force_and_status"] as u64,
+                ));
             } else {
                 let config = &self.config;
                 if let Some(payload) = self._fpga.request_ilc(
@@ -513,6 +519,12 @@ impl DataAcquisition {
             if let Some(frame_request) = self._ilc.get_frame_temperature(idx) {
                 if let Some(plant) = &mut self.plant {
                     frame_payload = plant.request_ilc(frame_request);
+
+                    // Sleep for a while to simulate the latency of the ILC in
+                    // the real hardware mode.
+                    sleep(Duration::from_micros(
+                        self.config.latency["temperature"] as u64,
+                    ));
                 } else {
                     let config = &self.config;
                     match self._fpga.request_ilc(
@@ -632,6 +644,12 @@ impl DataAcquisition {
 
             // Get the displacement sensor values as a frame.
             frame_payload = plant.request_ilc(frame_request);
+
+            // Sleep for a while to simulate the latency of the ILC in the real
+            // hardware mode.
+            sleep(Duration::from_micros(
+                self.config.latency["displacement"] as u64,
+            ));
         } else {
             match self._fpga.request_ilc(
                 frame_request,
@@ -721,6 +739,12 @@ impl DataAcquisition {
 
             // Get the inclinometer as a frame.
             frame_payload = plant.request_ilc(frame_request);
+
+            // Sleep for a while to simulate the latency of the ILC in the real
+            // hardware mode.
+            sleep(Duration::from_micros(
+                self.config.latency["inclinometer"] as u64,
+            ));
         } else {
             match self._fpga.request_ilc(
                 frame_request,

--- a/src/daq/data_acquisition.rs
+++ b/src/daq/data_acquisition.rs
@@ -160,11 +160,13 @@ impl DataAcquisition {
 
         info!("Set the data acquisition mode to: {:?}.", mode);
 
-        // Reset the current ILC stale data counts to 0 when switching to Idle
-        // mode as we do not read the ILC data in Idle mode.
+        // Reset the sequence ID and current ILC stale data counts to 0 when
+        // switching to Idle mode as we do not read the ILC data in Idle mode.
         if mode == DataAcquisitionMode::Idle {
-            self._ilc_stale_data_counts = vec![0; NUM_INNER_LOOP_CONTROLLER];
+            self._seq_id_move_actuator_steps = 0;
+            info!("Reset the sequence ID of the last move actuator steps command to 0.");
 
+            self._ilc_stale_data_counts = vec![0; NUM_INNER_LOOP_CONTROLLER];
             info!("Reset the current ILC stale data counts to 0.");
         }
 
@@ -1286,6 +1288,7 @@ mod tests {
             })]
         );
 
+        data_acquisition._seq_id_move_actuator_steps = 1;
         data_acquisition._ilc_stale_data_counts[0] = 5;
 
         assert!(data_acquisition
@@ -1300,6 +1303,7 @@ mod tests {
             })]
         );
 
+        assert_eq!(data_acquisition._seq_id_move_actuator_steps, 0);
         assert_eq!(data_acquisition._ilc_stale_data_counts[0], 0);
 
         // ClosedLoopControl -> Idle

--- a/src/daq/data_acquisition.rs
+++ b/src/daq/data_acquisition.rs
@@ -158,7 +158,7 @@ impl DataAcquisition {
         self.event_queue
             .add_event(Event::get_message_data_acquisition_mode(mode));
 
-        info!("Set the data acquisition mode to {:?}.", mode);
+        info!("Set the data acquisition mode to: {:?}.", mode);
 
         // Reset the current ILC stale data counts to 0 when switching to Idle
         // mode as we do not read the ILC data in Idle mode.
@@ -754,17 +754,22 @@ impl DataAcquisition {
                 continue;
             }
 
-            let has_wrong_communication_counter =
-                !self._ilc.is_expected_communication_counter(*status);
-            if has_wrong_communication_counter && (!has_broadcast_issue) {
-                has_broadcast_issue = true;
-            }
+            // Only check the communication counter when the ILC has moved the
+            // actuators. Otherwise, the ILC status is just some garbage data.
+            let mut has_wrong_communication_counter = false;
+            if telemetry.seq_id_move_actuator_steps > 0 {
+                has_wrong_communication_counter =
+                    !self._ilc.is_expected_communication_counter(*status);
+                if has_wrong_communication_counter && (!has_broadcast_issue) {
+                    has_broadcast_issue = true;
+                }
 
-            if has_wrong_communication_counter {
-                warn!(
-                    "The actuator ILC {} has the wrong communication counter.",
-                    idx
-                );
+                if has_wrong_communication_counter {
+                    warn!(
+                        "The actuator ILC {} has the wrong communication counter.",
+                        idx
+                    );
+                }
             }
 
             let has_fault = self.update_ilc_stale_data(
@@ -1445,6 +1450,7 @@ mod tests {
         data_acquisition.config.bypassed_actuator_ilcs = vec![1, 2];
 
         let mut telemetry = TelemetryControlLoop::new();
+        telemetry.seq_id_move_actuator_steps = 1;
 
         // Bypassed actuator ILCs should not be checked for stale data
         // Bit 4-7 is the broadcast communication counter

--- a/src/daq/data_acquisition.rs
+++ b/src/daq/data_acquisition.rs
@@ -271,26 +271,59 @@ impl DataAcquisition {
 
         let (ring, intake, exhaust, failed_to_read_temperature) =
             self.get_ilc_data_temperature(sleep_time_ilc_reading);
-        telemetry.temperature.insert(String::from("ring"), ring);
-        telemetry.temperature.insert(String::from("intake"), intake);
-        telemetry
-            .temperature
-            .insert(String::from("exhaust"), exhaust);
+
+        // Use the cached data for the bad readings of monitor ILCs.
+        if ring.iter().all(|x| x.is_finite())
+            && intake.iter().all(|x| x.is_finite())
+            && exhaust.iter().all(|x| x.is_finite())
+        {
+            telemetry.temperature.insert(String::from("ring"), ring);
+            telemetry.temperature.insert(String::from("intake"), intake);
+            telemetry
+                .temperature
+                .insert(String::from("exhaust"), exhaust);
+        } else {
+            telemetry.temperature = self._latest_telemetry.temperature.clone();
+            warn!(
+                "The temperature readings from ILCs are not valid. Use the cached temperature values.",
+            );
+        }
 
         let (theta_z, delta_z, failed_to_read_displacement) =
             self.get_ilc_data_displacement(sleep_time_ilc_reading);
-        telemetry
-            .displacement_sensors
-            .insert(String::from("thetaZ"), theta_z);
-        telemetry
-            .displacement_sensors
-            .insert(String::from("deltaZ"), delta_z);
+
+        // Use the cached data for the bad readings of monitor ILC.
+        if theta_z.iter().all(|x| x.is_finite()) && delta_z.iter().all(|x| x.is_finite()) {
+            telemetry
+                .displacement_sensors
+                .insert(String::from("thetaZ"), theta_z);
+            telemetry
+                .displacement_sensors
+                .insert(String::from("deltaZ"), delta_z);
+        } else {
+            telemetry.displacement_sensors = self._latest_telemetry.displacement_sensors.clone();
+            warn!(
+                "The displacement sensor readings from ILC are not valid. Use the cached displacement sensor values.",
+            );
+        }
 
         let (inclinometer_angle, mut failed_to_read_inclinometer) =
             self.get_ilc_data_inclinometer(sleep_time_ilc_reading);
-        telemetry
-            .inclinometer
-            .insert(String::from("raw"), inclinometer_angle);
+
+        // Use the cached data for the bad reading of monitor ILC.
+        if inclinometer_angle.is_finite() {
+            telemetry
+                .inclinometer
+                .insert(String::from("raw"), inclinometer_angle);
+        } else {
+            telemetry.inclinometer.insert(
+                String::from("raw"),
+                self._latest_telemetry.inclinometer["raw"],
+            );
+            warn!(
+                "The inclinometer reading from ILC is not valid. Use the cached inclinometer value.",
+            );
+        }
 
         // Bypass the check of the stale data for inclinometer if configured to
         // bypass.

--- a/src/daq/data_acquisition_process.rs
+++ b/src/daq/data_acquisition_process.rs
@@ -187,6 +187,7 @@ impl DataAcquisitionProcess {
         let mut counter_debug = 0;
 
         let period_loop = (1000.0 / config.frequency_loop) as u64;
+        let mut cycle_time = 0;
         let mut counter = 0;
         while !self._stop.load(Ordering::Relaxed) {
             // Time the data acquisition loop.
@@ -239,9 +240,11 @@ impl DataAcquisitionProcess {
             // When the system is not in idle mode, there is the ILC
             // telemetry data to send.
             if self.daq.mode != DataAcquisitionMode::Idle {
-                let _ = self
-                    ._sender_telemetry_to_control_loop
-                    .try_send(self.daq.get_telemetry_ilc());
+                // Track the cycle time for the ILC telemetry data.
+                let mut telemetry = self.daq.get_telemetry_ilc();
+                telemetry.cycle_time = cycle_time;
+
+                let _ = self._sender_telemetry_to_control_loop.try_send(telemetry);
             }
 
             // Toggle the bit of the closed-loop control for the safety module
@@ -257,7 +260,7 @@ impl DataAcquisitionProcess {
             }
 
             // Sleep with the remaining time.
-            let cycle_time = now.elapsed().as_millis() as u64;
+            cycle_time = now.elapsed().as_millis() as u64;
 
             if counter_debug >= max_counter_debug {
                 if self.daq.mode != DataAcquisitionMode::Idle {

--- a/src/daq/data_acquisition_process.rs
+++ b/src/daq/data_acquisition_process.rs
@@ -19,7 +19,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use log::{error, info};
+use log::{debug, error, info};
 use serde_json::Value;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -182,6 +182,10 @@ impl DataAcquisitionProcess {
         let config = &self.daq.config;
         let max_counter_toggle_bit = (config.frequency_loop / config.frequency_toggle_bit) as u64;
 
+        // Counter of the debug message to avoid flooding the log.
+        let max_counter_debug = config.frequency_loop as i32;
+        let mut counter_debug = 0;
+
         let period_loop = (1000.0 / config.frequency_loop) as u64;
         let mut counter = 0;
         while !self._stop.load(Ordering::Relaxed) {
@@ -254,6 +258,19 @@ impl DataAcquisitionProcess {
 
             // Sleep with the remaining time.
             let cycle_time = now.elapsed().as_millis() as u64;
+
+            if counter_debug >= max_counter_debug {
+                if self.daq.mode != DataAcquisitionMode::Idle {
+                    debug!(
+                        "Data acquisition process loop time when not idle: {} ms.",
+                        cycle_time
+                    );
+                }
+                counter_debug = 0;
+            } else {
+                counter_debug += 1;
+            }
+
             if period_loop > cycle_time {
                 sleep(Duration::from_millis(period_loop - cycle_time));
             }

--- a/src/error_handler.rs
+++ b/src/error_handler.rs
@@ -19,7 +19,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use strum::IntoEnumIterator;
@@ -266,13 +266,28 @@ impl ErrorHandler {
             } else {
                 self.add_error(ErrorCode::WarnMirrorTempSensor);
             }
+
+            debug!(
+                "Mirror temperature is out of range: {:?}.",
+                telemetry.temperature["ring"]
+            );
         }
 
         if self.is_temperature_out_of_range(&telemetry.temperature["intake"], true) {
             self.add_error(ErrorCode::WarnCellTemp);
+
+            debug!(
+                "Cell intake temperature is out of range: {:?}.",
+                telemetry.temperature["intake"]
+            );
         }
         if self.is_temperature_out_of_range(&telemetry.temperature["exhaust"], true) {
             self.add_error(ErrorCode::WarnCellTemp);
+
+            debug!(
+                "Cell exhaust temperature is out of range: {:?}.",
+                telemetry.temperature["exhaust"]
+            );
         }
 
         if self.is_cell_temperature_high(

--- a/src/error_handler.rs
+++ b/src/error_handler.rs
@@ -218,11 +218,32 @@ impl ErrorHandler {
         telemetry: &TelemetryControlLoop,
         is_closed_loop: bool,
     ) {
+        // Only check the ILC status and the related errors when the ILC has
+        // moved the actuators. Otherwise, the ILC status is just some garbage
+        // data.
+        if telemetry.seq_id_move_actuator_steps > 0 {
+            if self.is_encoder_out_limit(&telemetry.ilc_encoders, true) {
+                self.add_error(ErrorCode::FaultAxialActuatorEncoderRange);
+            }
+            if self.is_encoder_out_limit(&telemetry.ilc_encoders, false) {
+                self.add_error(ErrorCode::FaultTangentActuatorEncoderRange);
+            }
+
+            if self.is_actuator_force_out_limit(&telemetry.forces["measured"], is_closed_loop) {
+                self.add_error(ErrorCode::FaultExcessiveForce);
+            }
+
+            if self.is_tangent_force_error_out_limit(&telemetry.tangent_force_error) {
+                self.add_error(ErrorCode::FaultTangentLoadCell);
+            }
+
+            self.check_ilc_status(&telemetry.ilc_status);
+        }
+
         for error_code in &telemetry.ilc_error_codes {
             self.add_error(*error_code);
         }
 
-        self.check_ilc_status(&telemetry.ilc_status);
         if !self.ilc["fault"].is_empty() {
             self.add_error(ErrorCode::FaultActuatorIlcRead);
         }
@@ -237,21 +258,6 @@ impl ErrorHandler {
             };
 
             self.add_error(error_code_limit_switch);
-        }
-
-        if self.is_encoder_out_limit(&telemetry.ilc_encoders, true) {
-            self.add_error(ErrorCode::FaultAxialActuatorEncoderRange);
-        }
-        if self.is_encoder_out_limit(&telemetry.ilc_encoders, false) {
-            self.add_error(ErrorCode::FaultTangentActuatorEncoderRange);
-        }
-
-        if self.is_actuator_force_out_limit(&telemetry.forces["measured"], is_closed_loop) {
-            self.add_error(ErrorCode::FaultExcessiveForce);
-        }
-
-        if self.is_tangent_force_error_out_limit(&telemetry.tangent_force_error) {
-            self.add_error(ErrorCode::FaultTangentLoadCell);
         }
 
         if self.is_temperature_out_of_range(&telemetry.temperature["ring"], false) {
@@ -1011,6 +1017,7 @@ mod tests {
         let mut error_handler = create_error_handler();
 
         let mut telemetry = TelemetryControlLoop::new();
+        telemetry.seq_id_move_actuator_steps = 1;
         if let Some(value) = telemetry.forces.get_mut("measured") {
             value[1] = 1000.0;
         }

--- a/src/error_handler.rs
+++ b/src/error_handler.rs
@@ -573,9 +573,11 @@ impl ErrorHandler {
     /// Check the cycle time.
     ///
     /// # Arguments
-    /// * `cycle_time` - The cycle time in second.
-    fn check_cycle_time(&mut self, cycle_time: f64) {
-        if cycle_time > (1.0 / self.config_control_loop.control_frequency) {
+    /// * `cycle_time` - The cycle time in milliseconds.
+    fn check_cycle_time(&mut self, cycle_time: u64) {
+        // The frequencies of the control loop process and the data acquisition
+        // process should be the same.
+        if cycle_time > ((1000.0 / self.config_control_loop.control_frequency) as u64) {
             self._count_out_max_cycle_time += 1;
         } else {
             self._count_out_max_cycle_time = 0;
@@ -1307,27 +1309,27 @@ mod tests {
         let mut error_handler = create_error_handler();
 
         // Normal cycle time
-        error_handler.check_cycle_time(0.001);
+        error_handler.check_cycle_time(45);
         assert_eq!(error_handler._count_out_max_cycle_time, 0);
 
         // Has the warning error
         let max_out_cycle_time = error_handler.config_control_loop.max_out_cycle_time;
 
         for _ in 0..(max_out_cycle_time - 1) {
-            error_handler.check_cycle_time(1.0);
+            error_handler.check_cycle_time(51);
         }
 
         assert!(error_handler.has_error(ErrorCode::WarnCrioTiming));
         assert!(!error_handler.has_error(ErrorCode::FaultCrioTiming));
 
         // Has the fault error
-        error_handler.check_cycle_time(1.0);
+        error_handler.check_cycle_time(51);
 
         assert!(error_handler.has_error(ErrorCode::WarnCrioTiming));
         assert!(error_handler.has_error(ErrorCode::FaultCrioTiming));
 
         // Clear the warning error but the fault error still exists
-        error_handler.check_cycle_time(0.001);
+        error_handler.check_cycle_time(45);
 
         assert!(!error_handler.has_error(ErrorCode::WarnCrioTiming));
         assert!(error_handler.has_error(ErrorCode::FaultCrioTiming));

--- a/src/model.rs
+++ b/src/model.rs
@@ -1517,6 +1517,14 @@ mod tests {
         let mut model = create_model();
         model._stop_publish_telemetry = true;
 
+        // Modify the control frequency here to avoid the cRIO timing error
+        // in the ErrorHandler.check_cycle_time().
+        model
+            ._controller
+            .error_handler
+            .config_control_loop
+            .control_frequency = 1.0;
+
         model.run_processes();
 
         // Create the clients to connect the servers

--- a/src/power/config_power.rs
+++ b/src/power/config_power.rs
@@ -284,8 +284,8 @@ mod tests {
     fn test_get_time_power_off() {
         let config = ConfigPower::new();
 
-        assert_eq!(config.get_time_power_off(PowerType::Motor), 300);
-        assert_eq!(config.get_time_power_off(PowerType::Communication), 50);
+        assert_eq!(config.get_time_power_off(PowerType::Motor), 400);
+        assert_eq!(config.get_time_power_off(PowerType::Communication), 200);
     }
 
     #[test]

--- a/src/power/sub_power_system.rs
+++ b/src/power/sub_power_system.rs
@@ -334,9 +334,10 @@ impl SubPowerSystem {
                     let has_error = voltage >= self._output_voltage_off_level;
                     if has_error {
                         error!(
-                            "Powering off failed: has the relay open fault for power system ({:?}) in power system state: {:?}.",
+                            "Powering off failed: has the relay open fault for power system ({:?}) in power system state: {:?}. Current voltage: {:?} V.",
                             self.power_type,
-                            PowerSystemState::PoweringOff
+                            PowerSystemState::PoweringOff,
+                            voltage,
                         );
                     }
 

--- a/src/telemetry/telemetry_control_loop.rs
+++ b/src/telemetry/telemetry_control_loop.rs
@@ -64,8 +64,8 @@ pub struct TelemetryControlLoop {
     // Force balance based on the hardpoint correction. The unit are Newton for
     // the forces and Newton * meter for the moments.
     pub force_balance: HashMap<String, f64>,
-    // Cycle time in second.
-    pub cycle_time: f64,
+    // Cycle time in milliseconds.
+    pub cycle_time: u64,
     // Sequence ID of the last command to move actuator steps
     // (see CommandMoveActuatorSteps).
     pub seq_id_move_actuator_steps: i32,
@@ -141,7 +141,7 @@ impl TelemetryControlLoop {
             tangent_force_error: vec![0.0; NUM_TANGENT_LINK + 2],
             force_balance: Self::initialize_dict_value(&["fx", "fy", "fz", "mx", "my", "mz"], 0.0),
 
-            cycle_time: 0.0,
+            cycle_time: 0,
 
             seq_id_move_actuator_steps: 0,
 


### PR DESCRIPTION
- Update the `ErrorHandler.check_condition_control_loop()` to only check the actuator ILC after broadcasting the `step()` command to actuator ILCs.
- Add the debug messages in **ErrorHandler**.
- Update the `ErrorHandler.check_cycle_time()` to pass the cycle_time as milliseconds.
- Update the `DataAcquisition.check_ilc_stale_data()` that only check the communication counter after broadcasting the `step()` command to ILCs.
- Reset the `DataAcquisition._seq_id_move_actuator_steps` when transitioning to the **Idle** mode.
- Add the `ControlLoop.get_control_mode()`.
- Use the cached ILC monitor data if the received values are inf in **DataAcquisition**.
- Reset the `seq_id_move_actuator_steps` in `ControlLoopProcess.run()`.
- Improve the error message in **SubPowerSystem**.
- Update the **output_voltage_fall_time_communication** and **output_voltage_fall_time_motor** in `parameters_power.yaml`.
- Change the unit of `TelemetryControlLoop.cycle_time` to be milliseconds.
- Add the debug message for the loop time in **DataAcquisitionProcess** and record the `cycle_time`.
- Compare and record the cycle times of **ControlLoopProcess** and **DataAcquisitionProcess**.
- Simulate the ILC latency in **DataAcquisition**.