### PR TITLE
Tickets/osw 2432

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "run_m2"
-version = "0.1.0"
+version = "0.5.4"
 dependencies = [
  "approx",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "run_m2"
-version = "0.1.0"
+version = "0.5.4"
 edition = "2021"
 build = "build.rs"
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,18 @@ cargo run --features fpga --bin test_fpga
 The system should look for the `/usr/lib/x86_64-linux-gnu/libNiFpga.so` by itself at compile time.
 See the [build.rs](build.rs).
 
+## Executables
+
+The followings are the executables:
+
+- [main](src/main.rs): M2 controller.
+- [test_fpga](src/bin/test_fpga.rs): Test script of FPGA for the M2 cRIO simulator in the electronic lab.
+This cRIO is the same model of the current cRIO of M2.
+It has the same NI modules as well.
+
 ## Build the Executable
 
-Do the following to build the executable:
+Do the following to build the M2 controller executable:
 
 ```bash
 cargo build --release --features fpga,realtime

--- a/doc/version_history.md
+++ b/doc/version_history.md
@@ -1,5 +1,12 @@
 # Version History
 
+0.5.4
+
+- Update the log level in `Model.check_condition_control_loop()`.
+- Fix the bug that the raw ILC telemetry might not be processed when the received step command sequence id is not expected in `ControlLoopProcess.run()`.
+- Update the `DataAcquisitionProcess.run()` to continue to process the command after receiving the set mode command.
+- Update the `README.md`.
+
 0.5.3
 
 - Add the `libc` dependency.

--- a/src/control/control_loop_process.rs
+++ b/src/control/control_loop_process.rs
@@ -19,7 +19,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use log::{error, info};
+use log::{error, info, warn};
 use serde_json::{json, Value};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -165,12 +165,18 @@ impl ControlLoopProcess {
 
             // Process the received telemetry from the data acquisition.
             if let Some(telemetry) = &mut processed_telemetry {
+                self.control_loop.process_telemetry_data(telemetry);
+
                 // We need to check the sequence ID here because we need to
                 // make sure the new telemetry is the expected one that the
-                // inner-loop controlloer (ILC) has moved the actuators.
+                // inner-loop controller (ILC) has moved the actuators.
                 if telemetry.seq_id_move_actuator_steps == seq_id_move_actuator_steps {
-                    self.control_loop.process_telemetry_data(telemetry);
                     self.control_loop.step(telemetry);
+                } else {
+                    warn!(
+                        "The step sequence ID of the received ILC raw telemetry is {}, which is different from the expected sequence ID {}. The control loop will not step based on this telemetry.",
+                        telemetry.seq_id_move_actuator_steps, seq_id_move_actuator_steps
+                    );
                 }
             }
 

--- a/src/daq/data_acquisition_process.rs
+++ b/src/daq/data_acquisition_process.rs
@@ -34,7 +34,7 @@ use crate::command::{
         CommandGetInnerLoopControlMode, CommandMoveActuatorSteps, CommandSetDataAcquisitionMode,
         CommandSetInnerLoopControlMode, CommandSwitchDigitalOutput,
     },
-    command_schema::CommandSchema,
+    command_schema::{Command, CommandSchema},
 };
 use crate::constants::BOUND_SYNC_CHANNEL;
 use crate::daq::data_acquisition::DataAcquisition;
@@ -43,7 +43,7 @@ use crate::telemetry::{
     telemetry::Telemetry, telemetry_control_loop::TelemetryControlLoop,
     telemetry_power::TelemetryPower,
 };
-use crate::utility::get_message_sequence_id;
+use crate::utility::{get_message_name, get_message_sequence_id};
 
 pub struct DataAcquisitionProcess {
     // Data acquisition (DAQ) system
@@ -186,6 +186,9 @@ impl DataAcquisitionProcess {
         let max_counter_debug = (config.frequency_loop as i32) - 1;
         let mut counter_debug = 0;
 
+        // Command name for setting the data acquisition mode.
+        let set_mode_command_name = CommandSetDataAcquisitionMode.name();
+
         let period_loop = (1000.0 / config.frequency_loop) as u64;
         let mut cycle_time = 0;
         let mut counter = 0;
@@ -194,20 +197,21 @@ impl DataAcquisitionProcess {
             let now = Instant::now();
 
             // Process the message.
+            // If this is a set mode command, we need to process the next
+            // message (if any) as well. This is because if the control loop is
+            // under the open-loop control mode or closed-loop control mode,
+            // the control loop process will send the step() command regularly
+            // and we need to process it.
             let mut command_result = None;
+            let mut is_set_mode_command = false;
             if let Ok(message) = self._receiver_to_daq.try_recv() {
-                command_result = Some(self._command_schema.execute(
-                    &message,
-                    Some(&mut self.daq),
-                    None,
-                    None,
-                    None,
-                ));
+                command_result = self.execute_and_check_internal_command(&message);
+                is_set_mode_command = get_message_name(&message) == set_mode_command_name;
+            }
 
-                // For the internal command, no need to send the result.
-                let is_internal_command = get_message_sequence_id(&message) == -1;
-                if is_internal_command {
-                    command_result = None;
+            if is_set_mode_command && command_result.is_none() {
+                if let Ok(message) = self._receiver_to_daq.try_recv() {
+                    command_result = self.execute_and_check_internal_command(&message);
                 }
             }
 
@@ -284,6 +288,27 @@ impl DataAcquisitionProcess {
         self.daq.end_default_digital_output();
 
         info!("Data acquisition loop is stopped.");
+    }
+
+    /// Execute a command and check if it's an internal command.
+    ///
+    /// # Arguments
+    /// * `message` - The message to execute.
+    ///
+    /// # Returns
+    /// The command result, or None if it's an internal command.
+    fn execute_and_check_internal_command(&mut self, message: &Value) -> Option<Value> {
+        let result = self
+            ._command_schema
+            .execute(message, Some(&mut self.daq), None, None, None);
+
+        // For the internal command, no need to send the result.
+        let is_internal_command = get_message_sequence_id(message) == -1;
+        if is_internal_command {
+            None
+        } else {
+            Some(result)
+        }
     }
 }
 
@@ -435,5 +460,37 @@ mod tests {
         stop.store(true, Ordering::Relaxed);
 
         assert!(handle.join().is_ok());
+    }
+
+    #[test]
+    fn test_execute_and_check_internal_command() {
+        let mut data_acquisition_process = create_data_acquisition_process().0;
+
+        // Test an internal command.
+        let command_internal = json!({
+            "id": "cmd_setDataAcquisitionMode",
+            "mode": 2,
+        });
+        let result_internal =
+            data_acquisition_process.execute_and_check_internal_command(&command_internal);
+
+        assert!(result_internal.is_none());
+
+        // Test a non-internal command.
+        let command_external = json!({
+            "id": "cmd_setDataAcquisitionMode",
+            "sequence_id": 2,
+            "mode": 2,
+        });
+        let result_external =
+            data_acquisition_process.execute_and_check_internal_command(&command_external);
+
+        assert_eq!(
+            result_external.unwrap(),
+            json!({
+                "id": "success",
+                "sequence_id": 2,
+            })
+        );
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -917,7 +917,7 @@ impl Model {
                 .update_closed_loop_control_mode(ClosedLoopControlMode::TelemetryOnly)
                 .is_none()
             {
-                debug!("Failed to change the control mode to be telemetry only when there is the fault. Stopping the control system...");
+                error!("Failed to change the control mode to be telemetry only when there is the fault. Stopping the control system...");
 
                 self.stop();
             };


### PR DESCRIPTION
- Update the log level in `Model.check_condition_control_loop()`.
- Fix the bug that the raw ILC telemetry might not be processed when the received step command sequence id is not expected in `ControlLoopProcess.run()`.
- Update the `DataAcquisitionProcess.run()` to continue to process the command after receiving the set mode command.
- Update the `README.md`.