### PR TITLE
Fix the DataAcquisition.set_or_get_scan_rate() for the simulation mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "run_m2"
-version = "0.5.4"
+version = "0.5.6"
 dependencies = [
  "approx",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "run_m2"
-version = "0.5.4"
+version = "0.5.6"
 edition = "2021"
 build = "build.rs"
 

--- a/doc/version_history.md
+++ b/doc/version_history.md
@@ -1,5 +1,14 @@
 # Version History
 
+0.5.6
+
+- Update the **MOCK_ILC_SCAN_RATE** in `mock_constants.rs`.
+- Fix the `DataAcquisition.set_or_get_scan_rate()` for the simulation mode.
+- Add the latency to `timeout_irq` in `DataAcquisition.reset_ilc()` and `DataAcquisition.set_offset_and_sensitivity()`.
+- Fix the `ServerIdentifier.from_frame()` and `ServerIdentifier.to_frame()`.
+- Do not check the ModBus timeout error when reading the server ID in `FpgaWrapper.read_ilc_frame()`.
+- Update the gains in `MockInnerLoopController.new()`.
+
 0.5.5
 
 - Add the new ILC command codes to `constants.rs`.

--- a/src/command/command_data_acquisition.rs
+++ b/src/command/command_data_acquisition.rs
@@ -226,7 +226,7 @@ impl Command for CommandGetScanRate {
         let system = data_acquisition?;
 
         let address = message["address"].as_u64()? as u8;
-        system.set_or_get_scan_rate(address, None, false)?;
+        system.set_or_get_scan_rate(address, None)?;
 
         Some(())
     }
@@ -251,7 +251,7 @@ impl Command for CommandSetScanRate {
 
         let address = message["address"].as_u64()? as u8;
         let rate = message["rate"].as_u64()? as u8;
-        system.set_or_get_scan_rate(address, Some(rate), false)?;
+        system.set_or_get_scan_rate(address, Some(rate))?;
 
         Some(())
     }
@@ -526,7 +526,7 @@ mod tests {
                 None,
                 None
             )
-            .is_none());
+            .is_some());
     }
 
     #[test]
@@ -545,7 +545,7 @@ mod tests {
                 None,
                 None
             )
-            .is_none());
+            .is_some());
     }
 
     #[test]

--- a/src/daq/data_acquisition.rs
+++ b/src/daq/data_acquisition.rs
@@ -1320,6 +1320,11 @@ impl DataAcquisition {
 
     /// Reset the inner-loop controller (ILC).
     ///
+    /// # Notes
+    /// You will always get the FPGA CustomFpgaModbusError::TimeoutRead for the
+    /// actuator ILC until the related firmware is fixed and updated. The
+    /// monitor ILC work fine.
+    ///
     /// # Arguments
     /// * `address` - The 0-based address of ILC.
     ///
@@ -1334,13 +1339,16 @@ impl DataAcquisition {
                 frame_payload = plant.request_ilc(&frame_request);
             }
         } else {
+            // Change the unit of latency from microsecond to millisecond for
+            // the timeout_irq.
             let config = &self.config;
+            let latency = config.latency["reset"];
             frame_payload = self._fpga.request_ilc(
                 &frame_request,
                 1,
                 config.payload_byte["reset"],
-                config.latency["reset"],
-                config.timeout_irq,
+                latency,
+                config.timeout_irq + latency / 1000,
             )?;
 
             // Sleep for a while to make sure the ILC has processed the command
@@ -1359,18 +1367,10 @@ impl DataAcquisition {
     /// * `address` - The 0-based address of ILC.
     /// * `scan_rate` - The scan rate to be set. If None, get the current scan
     ///   rate.
-    /// * `bypass_check_function_code` - A boolean indicating whether to bypass
-    ///   the check of the function code in the response frame. This is for the
-    ///   unit test purpose.
     ///
     /// # Returns
     /// Some with the current scan rate if successful. Otherwise, None.
-    pub fn set_or_get_scan_rate(
-        &mut self,
-        address: u8,
-        scan_rate: Option<u8>,
-        bypass_check_function_code: bool,
-    ) -> Option<u8> {
+    pub fn set_or_get_scan_rate(&mut self, address: u8, scan_rate: Option<u8>) -> Option<u8> {
         let frame_request = match scan_rate {
             Some(rate) => self._ilc.create_frame_set_scan_rate(address, rate),
             None => self._ilc.create_frame_get_scan_rate(address),
@@ -1401,7 +1401,7 @@ impl DataAcquisition {
             return None;
         }
 
-        let received_function_code = if bypass_check_function_code {
+        let received_function_code = if self.is_simulation_mode() {
             CODE_SCAN_RATE
         } else {
             self._fpga
@@ -1452,13 +1452,16 @@ impl DataAcquisition {
                 frame_payload = plant.request_ilc(&frame_request);
             }
         } else {
+            // Change the unit of latency from microsecond to millisecond for
+            // the timeout_irq.
             let config = &self.config;
+            let latency = config.latency["offset_and_sensitivity"];
             frame_payload = self._fpga.request_ilc(
                 &frame_request,
                 1,
                 config.payload_byte["offset_and_sensitivity"],
-                config.latency["offset_and_sensitivity"],
-                config.timeout_irq,
+                latency,
+                config.timeout_irq + latency / 1000,
             )?;
 
             // Sleep for a while to make sure the ILC has processed the command
@@ -2122,12 +2125,12 @@ mod tests {
         let address = 4;
         let scan_rate = 10;
         assert_eq!(
-            data_acquisition.set_or_get_scan_rate(address, Some(scan_rate), true),
+            data_acquisition.set_or_get_scan_rate(address, Some(scan_rate)),
             Some(scan_rate)
         );
 
         assert_eq!(
-            data_acquisition.set_or_get_scan_rate(address, None, true),
+            data_acquisition.set_or_get_scan_rate(address, None),
             Some(scan_rate)
         );
 

--- a/src/daq/fpga_wrapper.rs
+++ b/src/daq/fpga_wrapper.rs
@@ -28,7 +28,7 @@ use std::path::Path;
 use std::thread::sleep;
 use std::time::Duration;
 
-use crate::constants::{BROADCAST_ADDRESS, IRQ_NUMBER_ILC, NUMBER_ILC_PORT};
+use crate::constants::{BROADCAST_ADDRESS, CODE_REPORT_SERVER_ID, IRQ_NUMBER_ILC, NUMBER_ILC_PORT};
 use crate::enums::{
     CustomFpgaModbusError, DigitalOutput, DigitalOutputStatus, IlcCommand, ModbusMode,
 };
@@ -1442,9 +1442,20 @@ impl FpgaWrapper {
         // Read all the elements in the Inbound FIFO
         let number = self.read_fifo_elements_inbound(0, 0)?.1;
         let response = self.read_fifo_elements_inbound(number, timeout)?.0;
+        let received_function_code = self.read_control_value_u8("indicatorReceivedFunctionCode")?;
+        debug!(
+            "Read {} bytes from the ILC. The received function code is: {}. The response is: {:?}.",
+            response.len(),
+            received_function_code,
+            response,
+        );
 
-        // Check if any Modbus error is indicated by the FPGA.
-        if self.has_modbus_error(modbus_error) {
+        // Check if any Modbus error is indicated by the FPGA. Bypass this when
+        // reporting the server ID and getting a timeout error, because this
+        // timeout is expected in this specific case.
+        let bypass_modbus_error_check = (received_function_code == CODE_REPORT_SERVER_ID)
+            && (modbus_error == CustomFpgaModbusError::TimeoutRead);
+        if (!bypass_modbus_error_check) && self.has_modbus_error(modbus_error) {
             return None;
         }
 

--- a/src/daq/server_identifier.rs
+++ b/src/daq/server_identifier.rs
@@ -52,10 +52,10 @@ impl ServerIdentifier {
     ///
     /// # Arguments
     /// * `frame` - The received frame containing the server identifier data.
-    ///   The first element is the length of the firmware name, followed by the
-    ///   unique ID, application type, network node type, selected options,
-    ///   network node options, firmware revision (major.minor), and firmware
-    ///   name.
+    ///   The first element is the total bytes without the byte count and CRC,
+    ///   followed by the unique ID, application type, network node type,
+    ///   selected options, network node options, firmware revision (
+    ///   major.minor), and firmware name.
     ///
     /// # Returns
     /// * `Option<ServerIdentifier>` - Some(ServerIdentifier) if the frame
@@ -65,10 +65,15 @@ impl ServerIdentifier {
             return None;
         }
 
-        let name_bytes = frame[0] as usize;
-        if (frame.len() < 13) || (frame.len() != (13 + name_bytes)) {
+        // 13 is the minimum payload and 1 here is the bytes of byte count.
+        let bytes_without_byte_count_and_crc = frame[0] as usize;
+        if (frame.len() < 13) || (frame.len() < (bytes_without_byte_count_and_crc + 1)) {
             return None;
         }
+
+        // Trim the firmware name.
+        let name = String::from_utf8_lossy(&frame[13..(bytes_without_byte_count_and_crc + 1)]);
+        let name_trim_end = name.trim_end();
 
         Some(Self {
             unique_id: u64::from_be_bytes([
@@ -79,7 +84,7 @@ impl ServerIdentifier {
             selected_options: frame[9],
             network_node_options: frame[10],
             firmware_revision: format!("{}.{}", frame[11], frame[12]),
-            firmware_name: String::from_utf8_lossy(&frame[13..]).to_string(),
+            firmware_name: name_trim_end.to_string(),
         })
     }
 
@@ -87,14 +92,15 @@ impl ServerIdentifier {
     ///
     /// Returns
     /// A byte array representing the server identifier data. The first element
-    /// is the length of the firmware name, followed by the unique ID,
-    /// application type, network node type, selected options, network node
-    /// options, firmware revision (major.minor), and firmware name.
+    /// is the total bytes without the byte count and CRC, followed by the
+    /// unique ID, application type, network node type, selected options,
+    /// network node options, firmware revision (major.minor), and firmware
+    /// name.
     pub fn to_frame(&self) -> Vec<u8> {
         let name_bytes = self.firmware_name.len();
         let mut frame = vec![0; 13 + name_bytes];
 
-        frame[0] = name_bytes as u8;
+        frame[0] = frame.len() as u8 - 1;
 
         // For the unique_id, we only use the last 6 bytes (48 bits) to fit
         // into the frame.
@@ -129,26 +135,87 @@ mod tests {
 
     #[test]
     fn test_from_frame() {
+        // Test data
         // Valid frame with server identifier data
-        let frame = [
-            0x04, 0x12, 0x34, 0x56, 0x78, 0x90, 0xF1, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, b't',
+        let frame_test = [
+            0x10, 0x12, 0x34, 0x56, 0x78, 0x90, 0xF1, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, b't',
             b'e', b's', b't',
         ];
 
-        let server_id = ServerIdentifier::from_frame(&frame).unwrap();
+        let server_id_test = ServerIdentifier::from_frame(&frame_test).unwrap();
 
-        assert_eq!(server_id.unique_id, 0x1234567890F1);
-        assert_eq!(server_id.application_type, 0x01);
-        assert_eq!(server_id.network_node_type, 0x02);
-        assert_eq!(server_id.selected_options, 0x03);
-        assert_eq!(server_id.network_node_options, 0x04);
-        assert_eq!(server_id.firmware_revision, "5.6");
-        assert_eq!(server_id.firmware_name, "test");
+        assert_eq!(server_id_test.unique_id, 0x1234567890F1);
+        assert_eq!(server_id_test.application_type, 0x01);
+        assert_eq!(server_id_test.network_node_type, 0x02);
+        assert_eq!(server_id_test.selected_options, 0x03);
+        assert_eq!(server_id_test.network_node_options, 0x04);
+        assert_eq!(server_id_test.firmware_revision, "5.6");
+        assert_eq!(server_id_test.firmware_name, "test");
 
         // Invalid frame length
         assert!(ServerIdentifier::from_frame(&[]).is_none());
         assert!(ServerIdentifier::from_frame(&[0x0F]).is_none());
-        assert!(ServerIdentifier::from_frame(&frame[0..(frame.len() - 1)]).is_none());
+        assert!(ServerIdentifier::from_frame(&frame_test[0..(frame_test.len() - 1)]).is_none());
+
+        // Real data (ILC 0)
+        let frame_ilc_0 = [
+            53, 0, 0, 23, 133, 83, 133, 1, 1, 1, 1, 7, 1, 69, 108, 101, 99, 116, 114, 111, 109,
+            101, 99, 104, 97, 110, 105, 99, 97, 108, 32, 73, 76, 67, 32, 40, 99, 41, 50, 48, 49,
+            55, 32, 65, 85, 82, 65, 45, 76, 83, 83, 84, 32, 32, 17, 204,
+        ];
+
+        let server_id_ilc_0 = ServerIdentifier::from_frame(&frame_ilc_0).unwrap();
+
+        assert_eq!(server_id_ilc_0.unique_id, 0x17855385);
+        assert_eq!(server_id_ilc_0.application_type, 0x01);
+        assert_eq!(server_id_ilc_0.network_node_type, 0x01);
+        assert_eq!(server_id_ilc_0.selected_options, 0x01);
+        assert_eq!(server_id_ilc_0.network_node_options, 0x01);
+        assert_eq!(server_id_ilc_0.firmware_revision, "7.1");
+        assert_eq!(
+            server_id_ilc_0.firmware_name,
+            "Electromechanical ILC (c)2017 AURA-LSST"
+        );
+
+        // Real data (ILC 78)
+        let frame_ilc_78 = [
+            56, 0, 0, 23, 132, 188, 248, 4, 4, 0, 0, 10, 0, 84, 101, 109, 112, 101, 114, 97, 116,
+            117, 114, 101, 32, 77, 111, 110, 105, 116, 111, 114, 105, 110, 103, 32, 73, 76, 67, 32,
+            40, 99, 41, 50, 48, 50, 52, 32, 65, 85, 82, 65, 45, 76, 83, 83, 84, 192, 106,
+        ];
+
+        let server_id_ilc_78 = ServerIdentifier::from_frame(&frame_ilc_78).unwrap();
+
+        assert_eq!(server_id_ilc_78.unique_id, 0x1784bcf8);
+        assert_eq!(server_id_ilc_78.application_type, 0x04);
+        assert_eq!(server_id_ilc_78.network_node_type, 0x04);
+        assert_eq!(server_id_ilc_78.selected_options, 0x0);
+        assert_eq!(server_id_ilc_78.network_node_options, 0x0);
+        assert_eq!(server_id_ilc_78.firmware_revision, "10.0");
+        assert_eq!(
+            server_id_ilc_78.firmware_name,
+            "Temperature Monitoring ILC (c)2024 AURA-LSST"
+        );
+
+        // Real data (ILC 83)
+        let frame_ilc_83 = [
+            57, 0, 0, 23, 132, 192, 79, 6, 6, 0, 0, 10, 0, 73, 110, 99, 108, 105, 110, 111, 109,
+            101, 116, 101, 114, 32, 77, 111, 110, 105, 116, 111, 114, 105, 110, 103, 32, 73, 76,
+            67, 32, 40, 99, 41, 50, 48, 50, 52, 32, 65, 85, 82, 65, 45, 76, 83, 83, 84, 187, 76,
+        ];
+
+        let server_id_ilc_83 = ServerIdentifier::from_frame(&frame_ilc_83).unwrap();
+
+        assert_eq!(server_id_ilc_83.unique_id, 0x1784c04f);
+        assert_eq!(server_id_ilc_83.application_type, 0x06);
+        assert_eq!(server_id_ilc_83.network_node_type, 0x06);
+        assert_eq!(server_id_ilc_83.selected_options, 0x0);
+        assert_eq!(server_id_ilc_83.network_node_options, 0x0);
+        assert_eq!(server_id_ilc_83.firmware_revision, "10.0");
+        assert_eq!(
+            server_id_ilc_83.firmware_name,
+            "Inclinometer Monitoring ILC (c)2024 AURA-LSST"
+        );
     }
 
     #[test]

--- a/src/mock/mock_constants.rs
+++ b/src/mock/mock_constants.rs
@@ -43,7 +43,7 @@ pub const MOCK_ILC_GAIN: f32 = 1.455705e-05;
 pub const MOCK_ILC_OFFSET: f32 = 0.0;
 pub const MOCK_ILC_SENSITIVITY: f32 = 1.60876;
 
-pub const MOCK_ILC_SCAN_RATE: u8 = 12;
+pub const MOCK_ILC_SCAN_RATE: u8 = 8;
 
 pub const MOCK_FIRMWARE_NAME: &str = "Electromechanical ILC (c)2017 AURA-LSST";
 pub const MOCK_FIRMWARE_REVISION: &str = "7.1";

--- a/src/mock/mock_inner_loop_controller.rs
+++ b/src/mock/mock_inner_loop_controller.rs
@@ -73,6 +73,11 @@ impl MockInnerLoopController {
     /// # Returns
     /// A new model with a random number.
     pub fn new(unique_id: u64) -> Self {
+        // For the current ILC on M2, only the second channel has a non-zero
+        // gain.
+        let mut gains = [0.0; NUM_ILC_CHANNEL];
+        gains[1] = MOCK_ILC_GAIN;
+
         Self {
             _crc: Crc::<u16>::new(&CRC_16_MODBUS),
 
@@ -95,7 +100,7 @@ impl MockInnerLoopController {
             },
             _scan_rate: MOCK_ILC_SCAN_RATE,
             _calibration_data: CalibrationData {
-                gains: [MOCK_ILC_GAIN; NUM_ILC_CHANNEL],
+                gains,
                 offsets: [MOCK_ILC_OFFSET; NUM_ILC_CHANNEL],
                 sensitivities: [MOCK_ILC_SENSITIVITY; NUM_ILC_CHANNEL],
             },


### PR DESCRIPTION
- Update the **MOCK_ILC_SCAN_RATE** in `mock_constants.rs`.
- Fix the `DataAcquisition.set_or_get_scan_rate()` for the simulation mode.
- Add the latency to `timeout_irq` in `DataAcquisition.reset_ilc()` and `DataAcquisition.set_offset_and_sensitivity()`.
- Fix the `ServerIdentifier.from_frame()` and `ServerIdentifier.to_frame()`.
- Do not check the ModBus timeout error when reading the server ID in `FpgaWrapper.read_ilc_frame()`.
- Update the gains in `MockInnerLoopController.new()`.